### PR TITLE
Añadir librería de documentación Spring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mapstruct:mapstruct:1.6.3'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
Se agregó la librería de Spring de OpenAPI para documentar la API de categorías.

Se documentaron los siguientes endspoints:

- GET /api/v1/category/
- POST /api/v1/category/

![SWAGGER](https://github.com/user-attachments/assets/0d386c4c-4410-4b48-b47c-a2580ed194aa)

