### PR TITLE
Añadir test unitarios para CategoryUseCase.save

### DIFF
--- a/src/test/java/com/powerup/realestate/category/domain/usecases/CategoryUseCaseTest.java
+++ b/src/test/java/com/powerup/realestate/category/domain/usecases/CategoryUseCaseTest.java
@@ -1,0 +1,59 @@
+package com.powerup.realestate.category.domain.usecases;
+
+import com.powerup.realestate.category.domain.exceptions.CategoryAlreadyExistsException;
+import com.powerup.realestate.category.domain.model.CategoryModel;
+import com.powerup.realestate.category.domain.ports.out.CategoryPersistencePort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CategoryUseCaseTest {
+     @Mock
+    private CategoryPersistencePort categoryPersistencePort;
+
+     @InjectMocks
+    private CategoryUseCase categoryUseCase;
+
+     @BeforeEach
+    void setUp() {
+         MockitoAnnotations.openMocks(this);
+     }
+
+     @Test
+    void save_ShouldSaveCategory_WhenCategoryDoesNotExist() {
+         CategoryModel categoryModel = new CategoryModel(
+                 (long) 1,
+                 "Test Category",
+                 "Test Description"
+         );
+
+         when(categoryPersistencePort.getCategoryByName("Test Category")).thenReturn(null);
+
+         categoryUseCase.save(categoryModel);
+
+         verify(categoryPersistencePort).getCategoryByName("Test Category");
+         verify(categoryPersistencePort).save(categoryModel);
+     }
+
+     @Test
+    void save_ShouldThrowException_WhenCategoryAlreadyExists() {
+         CategoryModel categoryModel = new CategoryModel(
+                 (long) 1,
+                 "Test Category",
+                 "Test Description"
+         );
+
+         when(categoryPersistencePort.getCategoryByName("Test Category")).thenReturn(categoryModel);
+
+         assertThrows(CategoryAlreadyExistsException.class, () -> categoryUseCase.save(categoryModel));
+
+         verify(categoryPersistencePort).getCategoryByName("Test Category");
+         verify(categoryPersistencePort, never()).save(categoryModel);
+
+     }
+}


### PR DESCRIPTION
Estos son tests unitarios para la clase CategoryUseCase, validando el comportamiento del método save:

1.  save_ShouldSaveCategory_WhenCategoryDoesNotExist

- Verifica que si la categoría no existe, se guarda correctamente.

2. save_ShouldThrowException_WhenCategoryAlreadyExists

- Confirma que si la categoría ya existe, se lanza una excepción CategoryAlreadyExistsException y no se guarda.

![image](https://github.com/user-attachments/assets/d0d5d96d-0b12-4c31-9b56-9d87e4c716d2)

