### PR TITLE
Añadir test unitario para  CategoryUseCase.getCategories

### DIFF
--- a/src/test/java/com/powerup/realestate/category/domain/usecases/CategoryUseCaseTest.java
+++ b/src/test/java/com/powerup/realestate/category/domain/usecases/CategoryUseCaseTest.java
@@ -3,11 +3,14 @@ package com.powerup.realestate.category.domain.usecases;
 import com.powerup.realestate.category.domain.exceptions.CategoryAlreadyExistsException;
 import com.powerup.realestate.category.domain.model.CategoryModel;
 import com.powerup.realestate.category.domain.ports.out.CategoryPersistencePort;
+import io.swagger.v3.oas.annotations.links.Link;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -55,5 +58,32 @@ class CategoryUseCaseTest {
          verify(categoryPersistencePort).getCategoryByName("Test Category");
          verify(categoryPersistencePort, never()).save(categoryModel);
 
+     }
+
+     @Test
+     void getCategories_ShouldReturnSortedList_WhenOrderIsAsc() {
+         CategoryModel categoryModel1 = new CategoryModel(
+                 (long) 1,
+                 "Name1",
+                 "Desc1"
+         );
+         CategoryModel categoryModel2 = new CategoryModel(
+                 (long) 2,
+                 "Name2",
+                 "Desc2"
+         );
+
+         Integer page = 1;
+         Integer size = 2;
+         boolean orderAsc = true;
+
+         List<CategoryModel> categoryList = List.of(categoryModel1, categoryModel2);
+
+         when(categoryPersistencePort.getCategories(page, size, orderAsc)).thenReturn(categoryList);
+
+         List<CategoryModel> paginatedCategoryList = categoryUseCase.getCategories(page, size, orderAsc);
+
+         verify(categoryPersistencePort).getCategories(page, size, orderAsc);
+         assertEquals(categoryList, paginatedCategoryList);
      }
 }


### PR DESCRIPTION
Este test verifica que el método getCategories de CategoryUseCase retorne una lista de categorías ordenadas ascendentemente cuando se le proporcionan los parámetros de paginación y orden.

![image](https://github.com/user-attachments/assets/37ca988a-b83f-418a-a16c-f411201103b2)

![image](https://github.com/user-attachments/assets/0a1527f3-24ba-4140-bbb0-51d5c4f3b40c)
