### PR TITLE
Feat/hu 6

### DIFF
--- a/src/main/java/com/powerup/realestate/RealEstateApplication.java
+++ b/src/main/java/com/powerup/realestate/RealEstateApplication.java
@@ -2,7 +2,9 @@ package com.powerup.realestate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class RealEstateApplication {
 

--- a/src/main/java/com/powerup/realestate/commons/configurations/beans/BeanConfiguration.java
+++ b/src/main/java/com/powerup/realestate/commons/configurations/beans/BeanConfiguration.java
@@ -56,7 +56,8 @@ public class BeanConfiguration {
     }
 
     @Bean
-    public LocationServicePort locationServicePort(LocationPersistencePort locationPersistencePort, CityServicePort cityServicePort) {
+    public LocationServicePort locationServicePort(LocationPersistencePort locationPersistencePort, CityServicePort cityServicePort)
+    {
 
         return new LocationUseCase(locationPersistencePort(), cityServicePort(cityPersistencePort()));
     }

--- a/src/main/java/com/powerup/realestate/commons/configurations/beans/BeanConfiguration.java
+++ b/src/main/java/com/powerup/realestate/commons/configurations/beans/BeanConfiguration.java
@@ -5,6 +5,7 @@ import com.powerup.realestate.location.domain.ports.out.CityPersistencePort;
 import com.powerup.realestate.location.domain.usecases.CityUseCase;
 import com.powerup.realestate.location.infrastructure.adapters.persistence.CityPersistenceAdapter;
 import com.powerup.realestate.location.infrastructure.repositories.mysql.CityRepository;
+import com.powerup.realestate.properties.application.services.PropertyValidationService;
 import com.powerup.realestate.properties.domain.ports.in.CategoryServicePort;
 import com.powerup.realestate.properties.domain.ports.in.PropertyServicePort;
 import com.powerup.realestate.properties.domain.ports.out.CategoryPersistencePort;
@@ -79,9 +80,8 @@ public class BeanConfiguration {
 
     @Bean
     public PropertyServicePort propertyServicePort(PropertyPersistencePort propertyPersistencePort,
-                                                   CategoryPersistencePort categoryPersistencePort,
-                                                   LocationPersistencePort locationPersistencePort) {
-        return new PropertyUseCase(propertyPersistencePort, null, categoryPersistencePort, null, locationPersistencePort);
+                                                   PropertyValidationService propertyValidationService) {
+        return new PropertyUseCase(propertyPersistencePort, propertyValidationService);
     }
 
 }

--- a/src/main/java/com/powerup/realestate/commons/configurations/beans/BeanConfiguration.java
+++ b/src/main/java/com/powerup/realestate/commons/configurations/beans/BeanConfiguration.java
@@ -6,10 +6,15 @@ import com.powerup.realestate.location.domain.usecases.CityUseCase;
 import com.powerup.realestate.location.infrastructure.adapters.persistence.CityPersistenceAdapter;
 import com.powerup.realestate.location.infrastructure.repositories.mysql.CityRepository;
 import com.powerup.realestate.properties.domain.ports.in.CategoryServicePort;
+import com.powerup.realestate.properties.domain.ports.in.PropertyServicePort;
 import com.powerup.realestate.properties.domain.ports.out.CategoryPersistencePort;
+import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
 import com.powerup.realestate.properties.domain.usecases.CategoryUseCase;
+import com.powerup.realestate.properties.domain.usecases.PropertyUseCase;
 import com.powerup.realestate.properties.infrastructure.adapters.persistence.CategoryPersistenceAdapter;
+import com.powerup.realestate.properties.infrastructure.adapters.persistence.PropertyPersistenceAdapter;
 import com.powerup.realestate.properties.infrastructure.mappers.CategoryEntityMapper;
+import com.powerup.realestate.properties.infrastructure.mappers.PropertyEntityMapper;
 import com.powerup.realestate.properties.infrastructure.repositories.mysql.CategoryRepository;
 import com.powerup.realestate.location.domain.ports.in.LocationServicePort;
 import com.powerup.realestate.location.domain.ports.out.LocationPersistencePort;
@@ -17,6 +22,7 @@ import com.powerup.realestate.location.domain.usecases.LocationUseCase;
 import com.powerup.realestate.location.infrastructure.adapters.persistence.LocationPersistenceAdapter;
 import com.powerup.realestate.location.infrastructure.mappers.LocationEntityMapper;
 import com.powerup.realestate.location.infrastructure.repositories.mysql.LocationRepository;
+import com.powerup.realestate.properties.infrastructure.repositories.mysql.PropertyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +35,14 @@ public class BeanConfiguration {
     private final LocationRepository locationRepository;
     private final LocationEntityMapper locationEntityMapper;
     private final CityRepository cityRepository;
+    private final PropertyRepository propertyRepository;
+    private final PropertyEntityMapper propertyEntityMapper;
+
+
+    @Bean
+    public CategoryPersistencePort categoryPersistencePort() {
+        return new CategoryPersistenceAdapter(categoryRepository, categoryEntityMapper);
+    }
 
     @Bean
     public CategoryServicePort categoryServicePort() {
@@ -37,9 +51,16 @@ public class BeanConfiguration {
     }
 
     @Bean
-    public CategoryPersistencePort categoryPersistencePort() {
-        return new CategoryPersistenceAdapter(categoryRepository, categoryEntityMapper);
+    public LocationPersistencePort locationPersistencePort() {
+        return new LocationPersistenceAdapter(locationRepository, locationEntityMapper);
     }
+
+    @Bean
+    public LocationServicePort locationServicePort(LocationPersistencePort locationPersistencePort, CityServicePort cityServicePort) {
+
+        return new LocationUseCase(locationPersistencePort(), cityServicePort(cityPersistencePort()));
+    }
+
     @Bean
     public CityPersistencePort cityPersistencePort() {
         return new CityPersistenceAdapter(cityRepository);
@@ -49,14 +70,15 @@ public class BeanConfiguration {
     public CityServicePort cityServicePort(CityPersistencePort cityPersistencePort) {
         return new CityUseCase(cityPersistencePort);
     }
-    @Bean
-    public LocationServicePort locationServicePort(LocationPersistencePort locationPersistencePort, CityServicePort cityServicePort) {
 
-        return new LocationUseCase(locationPersistencePort(), cityServicePort(cityPersistencePort()));
+    @Bean
+    public PropertyPersistencePort propertyPersistencePort() {
+        return new PropertyPersistenceAdapter(propertyRepository, propertyEntityMapper);
     }
 
     @Bean
-    public LocationPersistencePort locationPersistencePort() {
-        return new LocationPersistenceAdapter(locationRepository, locationEntityMapper);
+    public PropertyServicePort propertyServicePort() {
+        return  new PropertyUseCase(propertyPersistencePort());
     }
+
 }

--- a/src/main/java/com/powerup/realestate/commons/configurations/beans/BeanConfiguration.java
+++ b/src/main/java/com/powerup/realestate/commons/configurations/beans/BeanConfiguration.java
@@ -78,8 +78,10 @@ public class BeanConfiguration {
     }
 
     @Bean
-    public PropertyServicePort propertyServicePort() {
-        return  new PropertyUseCase(propertyPersistencePort());
+    public PropertyServicePort propertyServicePort(PropertyPersistencePort propertyPersistencePort,
+                                                   CategoryPersistencePort categoryPersistencePort,
+                                                   LocationPersistencePort locationPersistencePort) {
+        return new PropertyUseCase(propertyPersistencePort, null, categoryPersistencePort, null, locationPersistencePort);
     }
 
 }

--- a/src/main/java/com/powerup/realestate/commons/configurations/utils/Constants.java
+++ b/src/main/java/com/powerup/realestate/commons/configurations/utils/Constants.java
@@ -11,6 +11,5 @@ public final class Constants {
 
     public static final String SAVE_CATEGORY_RESPONSE_MESSAGE = "Categoría creada con éxito.";
     public static final String PAGEABLE_FIELD_NAME = "name";
-
     public static final String SAVE_PROPERTY_RESPONSE_MESSAGE = "Publicación creada con éxito.";
 }

--- a/src/main/java/com/powerup/realestate/commons/configurations/utils/Constants.java
+++ b/src/main/java/com/powerup/realestate/commons/configurations/utils/Constants.java
@@ -11,4 +11,6 @@ public final class Constants {
 
     public static final String SAVE_CATEGORY_RESPONSE_MESSAGE = "Categoría creada con éxito.";
     public static final String PAGEABLE_FIELD_NAME = "name";
+
+    public static final String SAVE_PROPERTY_RESPONSE_MESSAGE = "Publicación creada con éxito.";
 }

--- a/src/main/java/com/powerup/realestate/location/application/mappers/LocationDtoMapper.java
+++ b/src/main/java/com/powerup/realestate/location/application/mappers/LocationDtoMapper.java
@@ -22,6 +22,17 @@ public interface LocationDtoMapper {
     LocationResponse modelToResponse(LocationModel locationModel);
     PageResult<LocationResponse> modelListToResponseList(PageResult<LocationModel> locations);
 
+    default LocationModel toLocationModel(Long id) {
+        if (id == null) {
+            return null;
+        }
+        return LocationModel.builder().id(id).build();
+    }
+
+    default Long getIdFromLocationModel(LocationModel locationModel) {
+        return locationModel != null ? locationModel.getId() : null;
+    }
+
     @Named("mapCityNameToEntity")
     default CityEntity mapCityNameToEntity(String cityName) {
         if (cityName == null) {

--- a/src/main/java/com/powerup/realestate/location/domain/model/LocationModel.java
+++ b/src/main/java/com/powerup/realestate/location/domain/model/LocationModel.java
@@ -18,9 +18,7 @@ public class LocationModel {
     private  String neighborhood;
 
     public LocationModel(Long id, CityEntity cityName, String neighborhood) {
-        if (neighborhood == null || neighborhood.trim().isEmpty()) {
-            throw new NeighborhoodNonNullException();
-        }
+
 
         this.id = id;
         this.cityName = cityName;

--- a/src/main/java/com/powerup/realestate/location/domain/model/LocationModel.java
+++ b/src/main/java/com/powerup/realestate/location/domain/model/LocationModel.java
@@ -3,11 +3,12 @@ package com.powerup.realestate.location.domain.model;
 import com.powerup.realestate.location.domain.exceptions.NeighborhoodNonNullException;
 import com.powerup.realestate.location.domain.utils.constants.LocationDomainConstants;
 import com.powerup.realestate.location.infrastructure.entities.CityEntity;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.Objects;
-
+@Builder
 @Getter
 public class LocationModel {
 

--- a/src/main/java/com/powerup/realestate/location/domain/model/LocationModel.java
+++ b/src/main/java/com/powerup/realestate/location/domain/model/LocationModel.java
@@ -1,6 +1,5 @@
 package com.powerup.realestate.location.domain.model;
 
-import com.powerup.realestate.location.domain.exceptions.NeighborhoodNonNullException;
 import com.powerup.realestate.location.domain.utils.constants.LocationDomainConstants;
 import com.powerup.realestate.location.infrastructure.entities.CityEntity;
 import lombok.Builder;

--- a/src/main/java/com/powerup/realestate/location/domain/ports/in/LocationServicePort.java
+++ b/src/main/java/com/powerup/realestate/location/domain/ports/in/LocationServicePort.java
@@ -2,6 +2,7 @@ package com.powerup.realestate.location.domain.ports.in;
 
 import com.powerup.realestate.location.domain.model.LocationModel;
 import com.powerup.realestate.location.domain.utils.constants.page.PageResult;
+import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
 
 
 public interface LocationServicePort {

--- a/src/main/java/com/powerup/realestate/location/domain/ports/in/LocationServicePort.java
+++ b/src/main/java/com/powerup/realestate/location/domain/ports/in/LocationServicePort.java
@@ -2,10 +2,10 @@ package com.powerup.realestate.location.domain.ports.in;
 
 import com.powerup.realestate.location.domain.model.LocationModel;
 import com.powerup.realestate.location.domain.utils.constants.page.PageResult;
-import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
 
 
 public interface LocationServicePort {
     void save(LocationModel locationModel);
+    LocationModel findByLocationId(Long locationId);
     PageResult<LocationModel> getLocations(String searchText, Integer page, Integer size, boolean orderAsc);
 }

--- a/src/main/java/com/powerup/realestate/location/domain/ports/in/LocationServicePort.java
+++ b/src/main/java/com/powerup/realestate/location/domain/ports/in/LocationServicePort.java
@@ -3,9 +3,11 @@ package com.powerup.realestate.location.domain.ports.in;
 import com.powerup.realestate.location.domain.model.LocationModel;
 import com.powerup.realestate.location.domain.utils.constants.page.PageResult;
 
+import java.util.Optional;
+
 
 public interface LocationServicePort {
     void save(LocationModel locationModel);
-    LocationModel findByLocationId(Long locationId);
+    Optional<LocationModel> findByLocationId(Long locationId);
     PageResult<LocationModel> getLocations(String searchText, Integer page, Integer size, boolean orderAsc);
 }

--- a/src/main/java/com/powerup/realestate/location/domain/ports/out/LocationPersistencePort.java
+++ b/src/main/java/com/powerup/realestate/location/domain/ports/out/LocationPersistencePort.java
@@ -6,6 +6,7 @@ import com.powerup.realestate.location.domain.utils.constants.page.PageResult;
 
 public interface LocationPersistencePort {
     void save(LocationModel locationModel);
+    LocationModel findByLocationId(Long locationId);
     PageResult<LocationModel> getLocations(String searchText, Integer page, Integer size, boolean orderAsc);
 
 }

--- a/src/main/java/com/powerup/realestate/location/domain/ports/out/LocationPersistencePort.java
+++ b/src/main/java/com/powerup/realestate/location/domain/ports/out/LocationPersistencePort.java
@@ -3,10 +3,12 @@ package com.powerup.realestate.location.domain.ports.out;
 import com.powerup.realestate.location.domain.model.LocationModel;
 import com.powerup.realestate.location.domain.utils.constants.page.PageResult;
 
+import java.util.Optional;
+
 
 public interface LocationPersistencePort {
     void save(LocationModel locationModel);
-    LocationModel findByLocationId(Long locationId);
+    Optional<LocationModel> findByLocationId(Long locationId);
     PageResult<LocationModel> getLocations(String searchText, Integer page, Integer size, boolean orderAsc);
 
 }

--- a/src/main/java/com/powerup/realestate/location/domain/usecases/LocationUseCase.java
+++ b/src/main/java/com/powerup/realestate/location/domain/usecases/LocationUseCase.java
@@ -2,13 +2,15 @@ package com.powerup.realestate.location.domain.usecases;
 
 
 import com.powerup.realestate.location.domain.exceptions.CityNonExistentException;
+import com.powerup.realestate.location.domain.exceptions.NeighborhoodNonNullException;
 import com.powerup.realestate.location.domain.model.LocationModel;
 import com.powerup.realestate.location.domain.ports.in.CityServicePort;
 import com.powerup.realestate.location.domain.ports.in.LocationServicePort;
 import com.powerup.realestate.location.domain.ports.out.LocationPersistencePort;
 import com.powerup.realestate.location.domain.utils.constants.page.PageResult;
 import com.powerup.realestate.location.infrastructure.entities.CityEntity;
-import com.powerup.realestate.properties.domain.exceptions.LocationNotFoundException;
+
+import java.util.Optional;
 
 
 public class LocationUseCase implements LocationServicePort {
@@ -24,6 +26,11 @@ public class LocationUseCase implements LocationServicePort {
     @Override
     public void save(LocationModel locationModel) {
         CityEntity cityInfo = locationModel.getCityName();
+        String neighborhood = locationModel.getNeighborhood();
+
+        if (neighborhood == null || neighborhood.trim().isEmpty()) {
+            throw new NeighborhoodNonNullException();
+        }
 
         if (cityInfo != null && cityInfo.getName() != null && !cityInfo.getName().isEmpty()) {
             CityEntity cityEntity = cityServicePort.findCityByNameIgnoreCaseAndTrim(cityInfo.getName());
@@ -41,15 +48,12 @@ public class LocationUseCase implements LocationServicePort {
     }
 
     @Override
-    public LocationModel findByLocationId(Long locationId) {
+    public Optional<LocationModel> findByLocationId(Long locationId) {
         if (locationId == null) {
-            return null;
+            return Optional.empty();
         }
-        LocationModel locationModel = locationPersistencePort.findByLocationId(locationId);
-        if (locationModel == null) {
-            throw new LocationNotFoundException();
-        }
-        return locationModel;
+
+        return locationPersistencePort.findByLocationId(locationId);
     }
 
     @Override

--- a/src/main/java/com/powerup/realestate/location/domain/usecases/LocationUseCase.java
+++ b/src/main/java/com/powerup/realestate/location/domain/usecases/LocationUseCase.java
@@ -8,6 +8,7 @@ import com.powerup.realestate.location.domain.ports.in.LocationServicePort;
 import com.powerup.realestate.location.domain.ports.out.LocationPersistencePort;
 import com.powerup.realestate.location.domain.utils.constants.page.PageResult;
 import com.powerup.realestate.location.infrastructure.entities.CityEntity;
+import com.powerup.realestate.properties.domain.exceptions.LocationNotFoundException;
 
 
 public class LocationUseCase implements LocationServicePort {
@@ -38,6 +39,19 @@ public class LocationUseCase implements LocationServicePort {
         }
 
     }
+
+    @Override
+    public LocationModel findByLocationId(Long locationId) {
+        if (locationId == null) {
+            return null;
+        }
+        LocationModel locationModel = locationPersistencePort.findByLocationId(locationId);
+        if (locationModel == null) {
+            throw new LocationNotFoundException();
+        }
+        return locationModel;
+    }
+
     @Override
     public PageResult<LocationModel> getLocations(String searchText, Integer page, Integer size, boolean orderAsc) {
         return locationPersistencePort.getLocations(searchText, page, size, orderAsc);

--- a/src/main/java/com/powerup/realestate/location/infrastructure/adapters/persistence/LocationPersistenceAdapter.java
+++ b/src/main/java/com/powerup/realestate/location/infrastructure/adapters/persistence/LocationPersistenceAdapter.java
@@ -31,6 +31,11 @@ public class LocationPersistenceAdapter implements LocationPersistencePort {
     }
 
     @Override
+    public LocationModel findByLocationId(Long locationId) {
+        return locationEntityMapper.entityToModel(locationRepository.findById(locationId).orElse(null));
+    }
+
+    @Override
     public PageResult<LocationModel> getLocations(String searchText,Integer page, Integer size, boolean orderAsc) {
 
         Pageable pagination;

--- a/src/main/java/com/powerup/realestate/location/infrastructure/adapters/persistence/LocationPersistenceAdapter.java
+++ b/src/main/java/com/powerup/realestate/location/infrastructure/adapters/persistence/LocationPersistenceAdapter.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @Service
@@ -31,8 +32,9 @@ public class LocationPersistenceAdapter implements LocationPersistencePort {
     }
 
     @Override
-    public LocationModel findByLocationId(Long locationId) {
-        return locationEntityMapper.entityToModel(locationRepository.findById(locationId).orElse(null));
+    public Optional<LocationModel> findByLocationId(Long locationId) {
+        return locationRepository.findById(locationId)
+                .map(locationEntityMapper::entityToModel);
     }
 
     @Override

--- a/src/main/java/com/powerup/realestate/location/infrastructure/entities/CityEntity.java
+++ b/src/main/java/com/powerup/realestate/location/infrastructure/entities/CityEntity.java
@@ -2,11 +2,13 @@ package com.powerup.realestate.location.infrastructure.entities;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@Builder
 @Entity
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/powerup/realestate/location/infrastructure/entities/CityEntity.java
+++ b/src/main/java/com/powerup/realestate/location/infrastructure/entities/CityEntity.java
@@ -1,7 +1,6 @@
 package com.powerup.realestate.location.infrastructure.entities;
 
 import jakarta.persistence.*;
-import jakarta.security.auth.message.MessagePolicy;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/powerup/realestate/location/infrastructure/entities/DepartmentEntity.java
+++ b/src/main/java/com/powerup/realestate/location/infrastructure/entities/DepartmentEntity.java
@@ -2,11 +2,13 @@ package com.powerup.realestate.location.infrastructure.entities;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@Builder
 @Entity
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/powerup/realestate/location/infrastructure/entities/LocationEntity.java
+++ b/src/main/java/com/powerup/realestate/location/infrastructure/entities/LocationEntity.java
@@ -1,9 +1,12 @@
 package com.powerup.realestate.location.infrastructure.entities;
 
+import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Data
@@ -18,5 +21,7 @@ public class LocationEntity {
     @ManyToOne
     @JoinColumn(name = "city_id", nullable = false)
     private CityEntity cityName;
+    @OneToMany(mappedBy = "location", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<PropertyEntity> properties;
 
 }

--- a/src/main/java/com/powerup/realestate/location/infrastructure/entities/LocationEntity.java
+++ b/src/main/java/com/powerup/realestate/location/infrastructure/entities/LocationEntity.java
@@ -1,12 +1,10 @@
 package com.powerup.realestate.location.infrastructure.entities;
 
-import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
 
 @Entity
 @Data

--- a/src/main/java/com/powerup/realestate/location/infrastructure/entities/LocationEntity.java
+++ b/src/main/java/com/powerup/realestate/location/infrastructure/entities/LocationEntity.java
@@ -17,11 +17,8 @@ public class LocationEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String neighborhood ;
-
     @ManyToOne
     @JoinColumn(name = "city_id", nullable = false)
     private CityEntity cityName;
-    @OneToMany(mappedBy = "location", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<PropertyEntity> properties;
 
 }

--- a/src/main/java/com/powerup/realestate/location/infrastructure/repositories/mysql/LocationRepository.java
+++ b/src/main/java/com/powerup/realestate/location/infrastructure/repositories/mysql/LocationRepository.java
@@ -1,14 +1,17 @@
 package com.powerup.realestate.location.infrastructure.repositories.mysql;
 
 import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface LocationRepository extends JpaRepository<LocationEntity, Long> {
+
+    Optional<LocationEntity> findById(Long id);
 
     @Query("SELECT l FROM LocationEntity l\n" +
             "JOIN l.cityName c\n" +

--- a/src/main/java/com/powerup/realestate/location/infrastructure/repositories/mysql/LocationRepository.java
+++ b/src/main/java/com/powerup/realestate/location/infrastructure/repositories/mysql/LocationRepository.java
@@ -16,6 +16,6 @@ public interface LocationRepository extends JpaRepository<LocationEntity, Long> 
             "WHERE LOWER(l.neighborhood) LIKE LOWER(CONCAT('%', :searchText, '%'))\n" +
             "   OR LOWER(c.name) LIKE LOWER(CONCAT('%', :searchText, '%'))\n" +
             "   OR LOWER(d.name) LIKE LOWER(CONCAT('%', :searchText, '%'))\n" +
-            "ORDER BY c.name ASC, d.name ASC")  // Aquí busca en el departamento
+            "ORDER BY c.name ASC, d.name ASC")
     Page<LocationEntity> findByCityOrDepartment(@Param("searchText") String searchText, Pageable pageable);
 }

--- a/src/main/java/com/powerup/realestate/properties/application/dto/request/SavePropertyRequest.java
+++ b/src/main/java/com/powerup/realestate/properties/application/dto/request/SavePropertyRequest.java
@@ -1,10 +1,12 @@
 package com.powerup.realestate.properties.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-public record SavePropertyRequest(String name,String description,Long categoryId,Integer rooms, Integer bathrooms,
-                                 BigDecimal price, Long locationId, LocalDate activePublicationDate,
-                                 String publicationStatus, LocalDate publicationDate) {
+public record SavePropertyRequest(@NotBlank String name,@NotBlank String description,@NotBlank Long category,@NotBlank Integer rooms,@NotBlank Integer bathrooms,
+                                  @NotBlank BigDecimal price, @NotBlank Long location,@NotBlank LocalDate activePublicationDate) {
 
 }
 

--- a/src/main/java/com/powerup/realestate/properties/application/dto/request/SavePropertyRequest.java
+++ b/src/main/java/com/powerup/realestate/properties/application/dto/request/SavePropertyRequest.java
@@ -1,0 +1,10 @@
+package com.powerup.realestate.properties.application.dto.request;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record SavePropertyRequest(String name,String description,Long categoryId,Integer rooms, Integer bathrooms,
+                                 BigDecimal price, Long locationId, LocalDate activePublicationDate,
+                                 String publicationStatus, LocalDate publicationDate) {
+
+}
+

--- a/src/main/java/com/powerup/realestate/properties/application/dto/response/PropertyResponse.java
+++ b/src/main/java/com/powerup/realestate/properties/application/dto/response/PropertyResponse.java
@@ -3,8 +3,8 @@ package com.powerup.realestate.properties.application.dto.response;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-public record PropertyResponse(Long id, String name,String description,Long categoryId,Integer rooms, Integer bathrooms,
-    BigDecimal price, Long locationId, LocalDate activePublicationDate,
-    String publicationStatus, LocalDate publicationDate) {
+public record PropertyResponse(Long id, String name,String description,Long category,Integer rooms, Integer bathrooms,
+    BigDecimal price, Long location, LocalDate activePublicationDate,
+    String publicationStatus) {
 
     }

--- a/src/main/java/com/powerup/realestate/properties/application/dto/response/PropertyResponse.java
+++ b/src/main/java/com/powerup/realestate/properties/application/dto/response/PropertyResponse.java
@@ -1,0 +1,10 @@
+package com.powerup.realestate.properties.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record PropertyResponse(Long id, String name,String description,Long categoryId,Integer rooms, Integer bathrooms,
+    BigDecimal price, Long locationId, LocalDate activePublicationDate,
+    String publicationStatus, LocalDate publicationDate) {
+
+    }

--- a/src/main/java/com/powerup/realestate/properties/application/dto/response/SavePropertyResponse.java
+++ b/src/main/java/com/powerup/realestate/properties/application/dto/response/SavePropertyResponse.java
@@ -1,0 +1,6 @@
+package com.powerup.realestate.properties.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record SavePropertyResponse(String message, LocalDateTime time) {
+}

--- a/src/main/java/com/powerup/realestate/properties/application/mappers/CategoryDtoMapper.java
+++ b/src/main/java/com/powerup/realestate/properties/application/mappers/CategoryDtoMapper.java
@@ -13,6 +13,12 @@ import org.mapstruct.ReportingPolicy;
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CategoryDtoMapper {
     CategoryModel requestToModel(SaveCategoryRequest saveCategoryRequest);
-    CategoryResponse modelToResponse(CategoryModel categoryModel);
+    default CategoryModel toCategoryModel(Long id) {
+        return id == null ? null : CategoryModel.builder().id(id).build();
+    }
+    default Long toCategoryId(CategoryModel categoryModel) {
+        return categoryModel != null ? categoryModel.getId() : null;
+    }
+
     PageResult<CategoryResponse> modelListToResponseList(PageResult<CategoryModel> categories);
 }

--- a/src/main/java/com/powerup/realestate/properties/application/mappers/PropertyDtoMapper.java
+++ b/src/main/java/com/powerup/realestate/properties/application/mappers/PropertyDtoMapper.java
@@ -1,16 +1,50 @@
 package com.powerup.realestate.properties.application.mappers;
 
+import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
 import com.powerup.realestate.properties.application.dto.request.SavePropertyRequest;
 import com.powerup.realestate.properties.application.dto.response.PropertyResponse;
 import com.powerup.realestate.properties.domain.model.PropertyModel;
+import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
 import org.mapstruct.Mapper;
 
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface PropertyDtoMapper {
 
+    @Mapping(source = "locationId", target = "location", qualifiedByName = "mapLocationIdToEntity")
+    @Mapping(source = "categoryId", target = "category", qualifiedByName = "mapCategoryIdToEntity")
     PropertyModel requestToModel(SavePropertyRequest savePropertyRequest);
+    @Mapping(source = "location", target = "locationId", qualifiedByName = "mapLocationEntityToId")
+    @Mapping(source = "category", target = "categoryId", qualifiedByName = "mapCategoryEntityToId")
     PropertyResponse modelToResponse(PropertyModel propertyModel);
+
+    @Named("mapCategoryIdToEntity")
+    default CategoryEntity mapCategoryIdToEntity(Long id) {
+        if (id == null) return null;
+        CategoryEntity category = new CategoryEntity();
+        category.setId(id);
+        return category;
+    }
+
+    @Named("mapLocationIdToEntity")
+    default LocationEntity mapLocationIdToEntity(Long id) {
+        if (id == null) return null;
+        LocationEntity location = new LocationEntity();
+        location.setId(id);
+        return location;
+    }
+
+    @Named("mapCategoryEntityToId")
+    default Long mapCategoryEntityToId(CategoryEntity category) {
+        return category != null ? category.getId() : null;
+    }
+
+    @Named("mapLocationEntityToId")
+    default Long mapLocationEntityToId(LocationEntity location) {
+        return location != null ? location.getId() : null;
+    }
 }

--- a/src/main/java/com/powerup/realestate/properties/application/mappers/PropertyDtoMapper.java
+++ b/src/main/java/com/powerup/realestate/properties/application/mappers/PropertyDtoMapper.java
@@ -15,36 +15,8 @@ import org.mapstruct.ReportingPolicy;
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface PropertyDtoMapper {
 
-    @Mapping(source = "locationId", target = "locationId", qualifiedByName = "mapLocationIdToEntity")
-    @Mapping(source = "categoryId", target = "categoryId", qualifiedByName = "mapCategoryIdToEntity")
     PropertyModel  requestToModel(SavePropertyRequest savePropertyRequest);
-    @Mapping(source = "locationId", target = "locationId", qualifiedByName = "mapLocationEntityToId")
-    @Mapping(source = "categoryId", target = "categoryId", qualifiedByName = "mapCategoryEntityToId")
+    @Mapping(source = "locationId", target = "locationId")
+    @Mapping(source = "categoryId", target = "categoryId")
     PropertyResponse modelToResponse(PropertyModel propertyModel);
-
-    @Named("mapCategoryIdToEntity")
-    default CategoryEntity mapCategoryIdToEntity(Long id) {
-        if (id == null) return null;
-        CategoryEntity categoryEntity = new CategoryEntity();
-        categoryEntity.setId(id);
-        return categoryEntity;
-    }
-
-    @Named("mapLocationIdToEntity")
-    default LocationEntity mapLocationIdToEntity(Long id) {
-        if (id == null) return null;
-        LocationEntity locationEntity = new LocationEntity();
-        locationEntity.setId(id);
-        return locationEntity;
-    }
-
-    @Named("mapCategoryEntityToId")
-    default Long mapCategoryEntityToId(CategoryEntity category) {
-        return category != null ? category.getId() : null;
-    }
-
-    @Named("mapLocationEntityToId")
-    default Long mapLocationEntityToId(LocationEntity location) {
-        return location != null ? location.getId() : null;
-    }
 }

--- a/src/main/java/com/powerup/realestate/properties/application/mappers/PropertyDtoMapper.java
+++ b/src/main/java/com/powerup/realestate/properties/application/mappers/PropertyDtoMapper.java
@@ -15,27 +15,27 @@ import org.mapstruct.ReportingPolicy;
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface PropertyDtoMapper {
 
-    @Mapping(source = "locationId", target = "location", qualifiedByName = "mapLocationIdToEntity")
-    @Mapping(source = "categoryId", target = "category", qualifiedByName = "mapCategoryIdToEntity")
-    PropertyModel requestToModel(SavePropertyRequest savePropertyRequest);
-    @Mapping(source = "location", target = "locationId", qualifiedByName = "mapLocationEntityToId")
-    @Mapping(source = "category", target = "categoryId", qualifiedByName = "mapCategoryEntityToId")
+    @Mapping(source = "locationId", target = "locationId", qualifiedByName = "mapLocationIdToEntity")
+    @Mapping(source = "categoryId", target = "categoryId", qualifiedByName = "mapCategoryIdToEntity")
+    PropertyModel  requestToModel(SavePropertyRequest savePropertyRequest);
+    @Mapping(source = "locationId", target = "locationId", qualifiedByName = "mapLocationEntityToId")
+    @Mapping(source = "categoryId", target = "categoryId", qualifiedByName = "mapCategoryEntityToId")
     PropertyResponse modelToResponse(PropertyModel propertyModel);
 
     @Named("mapCategoryIdToEntity")
     default CategoryEntity mapCategoryIdToEntity(Long id) {
         if (id == null) return null;
-        CategoryEntity category = new CategoryEntity();
-        category.setId(id);
-        return category;
+        CategoryEntity categoryEntity = new CategoryEntity();
+        categoryEntity.setId(id);
+        return categoryEntity;
     }
 
     @Named("mapLocationIdToEntity")
     default LocationEntity mapLocationIdToEntity(Long id) {
         if (id == null) return null;
-        LocationEntity location = new LocationEntity();
-        location.setId(id);
-        return location;
+        LocationEntity locationEntity = new LocationEntity();
+        locationEntity.setId(id);
+        return locationEntity;
     }
 
     @Named("mapCategoryEntityToId")

--- a/src/main/java/com/powerup/realestate/properties/application/mappers/PropertyDtoMapper.java
+++ b/src/main/java/com/powerup/realestate/properties/application/mappers/PropertyDtoMapper.java
@@ -1,0 +1,16 @@
+package com.powerup.realestate.properties.application.mappers;
+
+import com.powerup.realestate.properties.application.dto.request.SavePropertyRequest;
+import com.powerup.realestate.properties.application.dto.response.PropertyResponse;
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+import org.mapstruct.Mapper;
+
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface PropertyDtoMapper {
+
+    PropertyModel requestToModel(SavePropertyRequest savePropertyRequest);
+    PropertyResponse modelToResponse(PropertyModel propertyModel);
+}

--- a/src/main/java/com/powerup/realestate/properties/application/mappers/PropertyDtoMapper.java
+++ b/src/main/java/com/powerup/realestate/properties/application/mappers/PropertyDtoMapper.java
@@ -1,22 +1,17 @@
 package com.powerup.realestate.properties.application.mappers;
 
-import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
+import com.powerup.realestate.location.application.mappers.LocationDtoMapper;
 import com.powerup.realestate.properties.application.dto.request.SavePropertyRequest;
 import com.powerup.realestate.properties.application.dto.response.PropertyResponse;
 import com.powerup.realestate.properties.domain.model.PropertyModel;
-import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
 import org.mapstruct.Mapper;
-
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring",
-        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = {CategoryDtoMapper.class, LocationDtoMapper.class})
 public interface PropertyDtoMapper {
 
     PropertyModel  requestToModel(SavePropertyRequest savePropertyRequest);
-    @Mapping(source = "locationId", target = "locationId")
-    @Mapping(source = "categoryId", target = "categoryId")
     PropertyResponse modelToResponse(PropertyModel propertyModel);
 }

--- a/src/main/java/com/powerup/realestate/properties/application/services/PropertyService.java
+++ b/src/main/java/com/powerup/realestate/properties/application/services/PropertyService.java
@@ -1,0 +1,12 @@
+package com.powerup.realestate.properties.application.services;
+
+
+
+import com.powerup.realestate.properties.application.dto.request.SavePropertyRequest;
+import com.powerup.realestate.properties.application.dto.response.SavePropertyResponse;
+
+
+public interface PropertyService {
+    SavePropertyResponse save(SavePropertyRequest request);
+}
+

--- a/src/main/java/com/powerup/realestate/properties/application/services/PropertyValidationService.java
+++ b/src/main/java/com/powerup/realestate/properties/application/services/PropertyValidationService.java
@@ -1,0 +1,11 @@
+package com.powerup.realestate.properties.application.services;
+
+import com.powerup.realestate.properties.domain.exceptions.CategoryNotFoundException;
+import com.powerup.realestate.properties.domain.exceptions.LocationNotFoundException;
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+
+public interface PropertyValidationService {
+
+    void validate(PropertyModel property)
+            throws  LocationNotFoundException, CategoryNotFoundException;
+}

--- a/src/main/java/com/powerup/realestate/properties/application/services/impl/PropertyServiceImpl.java
+++ b/src/main/java/com/powerup/realestate/properties/application/services/impl/PropertyServiceImpl.java
@@ -4,20 +4,17 @@ import com.powerup.realestate.commons.configurations.utils.Constants;
 import com.powerup.realestate.properties.application.dto.request.SavePropertyRequest;
 import com.powerup.realestate.properties.application.dto.response.SavePropertyResponse;
 import com.powerup.realestate.properties.application.mappers.PropertyDtoMapper;
-import com.powerup.realestate.properties.domain.model.PropertyModel;
 import com.powerup.realestate.properties.application.services.PropertyService;
 import com.powerup.realestate.properties.domain.ports.in.PropertyServicePort;
-import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
-import java.util.List;
+
 
 @Service
 @RequiredArgsConstructor
 public class PropertyServiceImpl implements PropertyService {
     private final PropertyServicePort propertyServicePort;
-    private final PropertyPersistencePort propertyPersistencePort;
     private final PropertyDtoMapper propertyDtoMapper;
 
 

--- a/src/main/java/com/powerup/realestate/properties/application/services/impl/PropertyServiceImpl.java
+++ b/src/main/java/com/powerup/realestate/properties/application/services/impl/PropertyServiceImpl.java
@@ -1,0 +1,30 @@
+package com.powerup.realestate.properties.application.services.impl;
+
+import com.powerup.realestate.commons.configurations.utils.Constants;
+import com.powerup.realestate.properties.application.dto.request.SavePropertyRequest;
+import com.powerup.realestate.properties.application.dto.response.SavePropertyResponse;
+import com.powerup.realestate.properties.application.mappers.PropertyDtoMapper;
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+import com.powerup.realestate.properties.application.services.PropertyService;
+import com.powerup.realestate.properties.domain.ports.in.PropertyServicePort;
+import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PropertyServiceImpl implements PropertyService {
+    private final PropertyServicePort propertyServicePort;
+    private final PropertyPersistencePort propertyPersistencePort;
+    private final PropertyDtoMapper propertyDtoMapper;
+
+
+    @Override
+    public SavePropertyResponse save(SavePropertyRequest request) {
+        propertyServicePort.save(propertyDtoMapper.requestToModel(request));
+        return new SavePropertyResponse(Constants.SAVE_PROPERTY_RESPONSE_MESSAGE, LocalDateTime.now());
+    }
+
+}

--- a/src/main/java/com/powerup/realestate/properties/application/services/impl/PropertyValidationServiceImp.java
+++ b/src/main/java/com/powerup/realestate/properties/application/services/impl/PropertyValidationServiceImp.java
@@ -1,0 +1,49 @@
+package com.powerup.realestate.properties.application.services.impl;
+
+import com.powerup.realestate.location.domain.model.LocationModel;
+import com.powerup.realestate.location.domain.ports.out.LocationPersistencePort;
+import com.powerup.realestate.properties.application.services.PropertyValidationService;
+import com.powerup.realestate.properties.domain.exceptions.CategoryNotFoundException;
+import com.powerup.realestate.properties.domain.exceptions.LocationNotFoundException;
+import com.powerup.realestate.properties.domain.model.CategoryModel;
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+import com.powerup.realestate.properties.domain.ports.out.CategoryPersistencePort;
+import com.powerup.realestate.properties.domain.utils.constants.PropertyDomainContants;
+import org.springframework.stereotype.Service;
+
+
+import java.util.Optional;
+
+@Service
+public class PropertyValidationServiceImp implements PropertyValidationService {
+    private final LocationPersistencePort locationPersistencePort;
+    private final CategoryPersistencePort categoryPersistencePort;
+
+    public PropertyValidationServiceImp(LocationPersistencePort locationPersistencePort, CategoryPersistencePort categoryPersistencePort) {
+        this.locationPersistencePort = locationPersistencePort;
+        this.categoryPersistencePort = categoryPersistencePort;
+    }
+
+    @Override
+    public void validate(PropertyModel property) throws  LocationNotFoundException, CategoryNotFoundException {
+
+        if (property.getLocation() == null) {
+            throw new IllegalArgumentException(PropertyDomainContants.FIELD_LOCATION_NULL_MESSAGE);
+        }
+        if (property.getCategory() == null) {
+            throw new IllegalArgumentException(PropertyDomainContants.FIELD_CATEGORY_NULL_MESSAGE);
+        }
+
+        Optional<LocationModel> locationModelOptional = locationPersistencePort.findByLocationId(property.getLocation().getId());
+        if (locationModelOptional.isEmpty()) {
+            throw new LocationNotFoundException();
+        }
+
+        Optional<CategoryModel> categoryModelOptional = categoryPersistencePort.getCategoryById(property.getCategory().getId());
+        if (categoryModelOptional.isEmpty()) {
+            throw new CategoryNotFoundException();
+        }
+
+    }
+}
+

--- a/src/main/java/com/powerup/realestate/properties/domain/exceptions/CategoryNotFoundException.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/exceptions/CategoryNotFoundException.java
@@ -1,0 +1,7 @@
+package com.powerup.realestate.properties.domain.exceptions;
+
+public class CategoryNotFoundException extends RuntimeException {
+    public CategoryNotFoundException() {
+        super();
+    }
+}

--- a/src/main/java/com/powerup/realestate/properties/domain/exceptions/InvalidActivePublicationDateException.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/exceptions/InvalidActivePublicationDateException.java
@@ -1,0 +1,7 @@
+package com.powerup.realestate.properties.domain.exceptions;
+
+public class InvalidActivePublicationDateException extends RuntimeException {
+    public InvalidActivePublicationDateException() {
+        super();
+    }
+}

--- a/src/main/java/com/powerup/realestate/properties/domain/exceptions/InvalidBathroomsException.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/exceptions/InvalidBathroomsException.java
@@ -1,0 +1,7 @@
+package com.powerup.realestate.properties.domain.exceptions;
+
+public class InvalidBathroomsException extends RuntimeException {
+    public InvalidBathroomsException() {
+        super();
+    }
+}

--- a/src/main/java/com/powerup/realestate/properties/domain/exceptions/InvalidPriceException.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/exceptions/InvalidPriceException.java
@@ -1,0 +1,7 @@
+package com.powerup.realestate.properties.domain.exceptions;
+
+public class InvalidPriceException extends RuntimeException {
+    public InvalidPriceException() {
+        super();
+    }
+}

--- a/src/main/java/com/powerup/realestate/properties/domain/exceptions/InvalidRoomsException.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/exceptions/InvalidRoomsException.java
@@ -1,0 +1,7 @@
+package com.powerup.realestate.properties.domain.exceptions;
+
+public class InvalidRoomsException extends RuntimeException {
+    public InvalidRoomsException() {
+        super();
+    }
+}

--- a/src/main/java/com/powerup/realestate/properties/domain/exceptions/LocationNotFoundException.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/exceptions/LocationNotFoundException.java
@@ -1,7 +1,7 @@
 package com.powerup.realestate.properties.domain.exceptions;
 
 public class LocationNotFoundException extends RuntimeException {
-    public LocationNotFoundException(String message) {
-        super(message);
+    public LocationNotFoundException() {
+        super();
     }
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/exceptions/LocationNotFoundException.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/exceptions/LocationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.powerup.realestate.properties.domain.exceptions;
+
+public class LocationNotFoundException extends RuntimeException {
+    public LocationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/powerup/realestate/properties/domain/model/CategoryModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/CategoryModel.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 import java.util.Objects;
 
-import static com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants.DESCRPTION_MAX_CHARACTERS;
+import static com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants.DESCRIPTION_MAX_CHARACTERS;
 import static com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants.NAME_MAX_CHARACTERS;
 
 public class CategoryModel {
@@ -18,7 +18,7 @@ public class CategoryModel {
 
     public CategoryModel(Long id, String name, String description) {
         if (name.length() > NAME_MAX_CHARACTERS) throw new NameMaxSizeExceededException();
-        if (description.length() > DESCRPTION_MAX_CHARACTERS) throw new DescriptionMaxSizeExceededException();
+        if (description.length() > DESCRIPTION_MAX_CHARACTERS) throw new DescriptionMaxSizeExceededException();
         this.id = id;
         this.name = Objects.requireNonNull(name, CategoryDomainConstants.FIELD_NAME_NULL_MESSAGE);
         this.description = Objects.requireNonNull(description,  CategoryDomainConstants.FIELD_DESCRIPTION_NULL_MESSAGE);
@@ -42,7 +42,7 @@ public class CategoryModel {
     }
 
     public void setDescription(String description) {
-        if (description.length() > DESCRPTION_MAX_CHARACTERS) throw new DescriptionMaxSizeExceededException();
+        if (description.length() > DESCRIPTION_MAX_CHARACTERS) throw new DescriptionMaxSizeExceededException();
         this.description = Objects.requireNonNull(description,  CategoryDomainConstants.FIELD_DESCRIPTION_NULL_MESSAGE);
     }
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/model/CategoryModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/CategoryModel.java
@@ -1,15 +1,13 @@
 package com.powerup.realestate.properties.domain.model;
 
-import com.powerup.realestate.properties.domain.exceptions.DescriptionMaxSizeExceededException;
-import com.powerup.realestate.properties.domain.exceptions.NameMaxSizeExceededException;
 import com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.Setter;
-
 import java.util.Objects;
 
-import static com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants.DESCRIPTION_MAX_CHARACTERS;
-import static com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants.NAME_MAX_CHARACTERS;
+
+@Getter
 @Builder
 public class CategoryModel {
     @Setter
@@ -18,32 +16,17 @@ public class CategoryModel {
     private String description;
 
     public CategoryModel(Long id, String name, String description) {
-        if (name.length() > NAME_MAX_CHARACTERS) throw new NameMaxSizeExceededException();
-        if (description.length() > DESCRIPTION_MAX_CHARACTERS) throw new DescriptionMaxSizeExceededException();
+
         this.id = id;
-        this.name = Objects.requireNonNull(name, CategoryDomainConstants.FIELD_NAME_NULL_MESSAGE);
-        this.description = Objects.requireNonNull(description,  CategoryDomainConstants.FIELD_DESCRIPTION_NULL_MESSAGE);
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
+        this.name = name;
+        this.description = description;
     }
 
     public void setName(String name) {
-        if (name.length() > NAME_MAX_CHARACTERS) throw new NameMaxSizeExceededException();
         this.name = Objects.requireNonNull(name, CategoryDomainConstants.FIELD_NAME_NULL_MESSAGE);
     }
 
-    public String getDescription() {
-        return description;
-    }
-
     public void setDescription(String description) {
-        if (description.length() > DESCRIPTION_MAX_CHARACTERS) throw new DescriptionMaxSizeExceededException();
         this.description = Objects.requireNonNull(description,  CategoryDomainConstants.FIELD_DESCRIPTION_NULL_MESSAGE);
     }
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/model/CategoryModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/CategoryModel.java
@@ -3,13 +3,14 @@ package com.powerup.realestate.properties.domain.model;
 import com.powerup.realestate.properties.domain.exceptions.DescriptionMaxSizeExceededException;
 import com.powerup.realestate.properties.domain.exceptions.NameMaxSizeExceededException;
 import com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants;
+import lombok.Builder;
 import lombok.Setter;
 
 import java.util.Objects;
 
 import static com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants.DESCRIPTION_MAX_CHARACTERS;
 import static com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants.NAME_MAX_CHARACTERS;
-
+@Builder
 public class CategoryModel {
     @Setter
     private Long id;

--- a/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
@@ -14,9 +14,8 @@ import java.util.Objects;
 import static com.powerup.realestate.properties.domain.utils.constants.PropertyDomainContants.*;
 
 @Getter
-@Setter
 public class PropertyModel {
-
+    @Setter
     private Long id;
     private String name;
     private String description;

--- a/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
@@ -1,55 +1,60 @@
 package com.powerup.realestate.properties.domain.model;
 
+import com.powerup.realestate.location.domain.model.LocationModel;
 import com.powerup.realestate.properties.domain.exceptions.InvalidActivePublicationDateException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidBathroomsException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidRoomsException;
 import com.powerup.realestate.properties.domain.utils.PublicationStatus;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
-
 import static com.powerup.realestate.properties.domain.utils.constants.PropertyDomainContants.*;
 
 @Getter
 @Builder
 public class PropertyModel {
 
+    @Setter
     private Long id;
     private String name;
     private String description;
-    private Long categoryId;
+    private CategoryModel category;
     private final int rooms;
     private final int bathrooms;
     private BigDecimal price;
-    private Long locationId;
+    private LocationModel location;
     private LocalDate activePublicationDate;
     private PublicationStatus publicationStatus;
     private LocalDate publicationDate;
 
 
-    public PropertyModel(Long id, String name, String description, Long categoryId,
-                         int rooms, int bathrooms, BigDecimal price, Long locationId,
+    public PropertyModel(Long id, String name, String description, CategoryModel category,
+                         int rooms, int bathrooms, BigDecimal price, LocationModel location,
                          LocalDate activePublicationDate, PublicationStatus publicationStatus, LocalDate publicationDate) {
         this.id = id;
         this.name = name;
         this.description = description;
-        this.categoryId = categoryId;
+        this.category = category;
         this.rooms = rooms;
         this.bathrooms = bathrooms;
         this.price = price;
-        this.locationId = locationId;
+        this.location = location;
         this.activePublicationDate = activePublicationDate;
-        this.publicationStatus = publicationStatus;
-        this.publicationDate = publicationDate;
+        this.publicationStatus = publicationStatus != null ? publicationStatus : PublicationStatus.PUBLISHING_PAUSED;
+        this.publicationDate = LocalDate.now();
 
 
         if (rooms < 0) throw new InvalidRoomsException();
+
         if (bathrooms < 0) throw new InvalidBathroomsException();
-        if (activePublicationDate != null &&  activePublicationDate.isAfter(LocalDate.now().plusMonths(1))) throw new InvalidActivePublicationDateException();
+
+        if (activePublicationDate.isAfter(LocalDate.now().plusMonths(1)))
+            throw new InvalidActivePublicationDateException();
 
     }
 
@@ -61,29 +66,22 @@ public class PropertyModel {
             this.description = Objects.requireNonNull(description, FIELD_DESCRIPTION_NULL_MESSAGE);
         }
 
-        public void setCategoryId(Long categoryId) {
-            this.categoryId = Objects.requireNonNull(categoryId, FIELD_CATEGORY_NULL_MESSAGE);
-        }
-
         public void setPrice(BigDecimal price) {
-            this.price = Objects.requireNonNull(price, FIELD_PRICE_NULL_MESSAGE);
-        }
-
-        public void setLocationId(Long locationId) {
-            this.locationId = Objects.requireNonNull(locationId, FIELD_LOCATION_NULL_MESSAGE);
+        this.price = Objects.requireNonNull(price, FIELD_PRICE_NULL_MESSAGE);
         }
 
         public void setActivePublicationDate(LocalDate activePublicationDate) {
-            if (activePublicationDate.isAfter(LocalDate.now().plusMonths(1))) throw new InvalidActivePublicationDateException();
+
+            if (activePublicationDate.isAfter(LocalDate.now().plusMonths(1)))
+                throw new InvalidActivePublicationDateException();
+
             this.activePublicationDate = Objects.requireNonNull(activePublicationDate, FIELD_ACTIVE_PUBLICATION_DATE_NULL_MESSAGE);
         }
 
-        public void setPublicationStatus(PublicationStatus publicationStatus) {
-            this.publicationStatus = Objects.requireNonNull(publicationStatus, FIELD_PUBLICATION_STATUS_NULL_MESSAGE);
-        }
-
-        public void setPublicationDate(LocalDate publicationDate) {
+    public void setPublicationDate(LocalDate publicationDate) {
             this.publicationDate = Objects.requireNonNull(publicationDate, FIELD_PUBLICATION_DATE_NULL_MESSAGE);
         }
 
+    public void setPublicationStatus(PublicationStatus publicationStatus) {
+    }
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
@@ -1,10 +1,12 @@
 package com.powerup.realestate.properties.domain.model;
 
+import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
 import com.powerup.realestate.properties.domain.exceptions.InvalidActivePublicationDateException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidBathroomsException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidRoomsException;
 
 import com.powerup.realestate.properties.domain.utils.PublicationStatus;
+import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -22,18 +24,18 @@ public class PropertyModel {
     private Long id;
     private String name;
     private String description;
-    private Long categoryId;
+    private CategoryEntity categoryId;
     private final int rooms;
     private final int bathrooms;
     private BigDecimal price;
-    private Long locationId;
+    private LocationEntity locationId;
     private LocalDate activePublicationDate;
     private PublicationStatus publicationStatus;
     private LocalDate publicationDate;
 
 
-    public PropertyModel(Long id, String name, String description, Long categoryId,
-                         int rooms, int bathrooms, BigDecimal price, Long locationId,
+    public PropertyModel(Long id, String name, String description, CategoryEntity categoryId,
+                         int rooms, int bathrooms, BigDecimal price, LocationEntity locationId,
                          LocalDate activePublicationDate, PublicationStatus publicationStatus, LocalDate publicationDate) {
         this.id = id;
         this.name = name;
@@ -62,7 +64,7 @@ public class PropertyModel {
             this.description = Objects.requireNonNull(description, FIELD_DESCRIPTION_NULL_MESSAGE);
         }
 
-        public void setCategoryId(Long categoryId) {
+        public void setCategoryId(CategoryEntity categoryId) {
             this.categoryId = Objects.requireNonNull(categoryId, FIELD_CATEGORY_NULL_MESSAGE);
         }
 
@@ -70,7 +72,7 @@ public class PropertyModel {
             this.price = Objects.requireNonNull(price, FIELD_PRICE_NULL_MESSAGE);
         }
 
-        public void setLocationId(Long locationId) {
+        public void setLocationId(LocationEntity locationId) {
             this.locationId = Objects.requireNonNull(locationId, FIELD_LOCATION_NULL_MESSAGE);
         }
 

--- a/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
@@ -4,6 +4,8 @@ import com.powerup.realestate.properties.domain.exceptions.InvalidActivePublicat
 import com.powerup.realestate.properties.domain.exceptions.InvalidBathroomsException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidRoomsException;
 
+import com.powerup.realestate.properties.domain.utils.PublicationStatus;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,24 +16,25 @@ import java.util.Objects;
 import static com.powerup.realestate.properties.domain.utils.constants.PropertyDomainContants.*;
 
 @Getter
+@Builder
 public class PropertyModel {
-    @Setter
+
     private Long id;
     private String name;
     private String description;
     private Long categoryId;
-    private int rooms;
-    private int bathrooms;
+    private final int rooms;
+    private final int bathrooms;
     private BigDecimal price;
     private Long locationId;
     private LocalDate activePublicationDate;
-    private String publicationStatus;
+    private PublicationStatus publicationStatus;
     private LocalDate publicationDate;
 
 
     public PropertyModel(Long id, String name, String description, Long categoryId,
                          int rooms, int bathrooms, BigDecimal price, Long locationId,
-                         LocalDate activePublicationDate, String publicationStatus, LocalDate publicationDate) {
+                         LocalDate activePublicationDate, PublicationStatus publicationStatus, LocalDate publicationDate) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -76,7 +79,7 @@ public class PropertyModel {
             this.activePublicationDate = Objects.requireNonNull(activePublicationDate, FIELD_ACTIVE_PUBLICATION_DATE_NULL_MESSAGE);
         }
 
-        public void setPublicationStatus(String publicationStatus) {
+        public void setPublicationStatus(PublicationStatus publicationStatus) {
             this.publicationStatus = Objects.requireNonNull(publicationStatus, FIELD_PUBLICATION_STATUS_NULL_MESSAGE);
         }
 

--- a/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
@@ -1,15 +1,12 @@
 package com.powerup.realestate.properties.domain.model;
 
-import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
 import com.powerup.realestate.properties.domain.exceptions.InvalidActivePublicationDateException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidBathroomsException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidRoomsException;
-
 import com.powerup.realestate.properties.domain.utils.PublicationStatus;
-import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -24,18 +21,18 @@ public class PropertyModel {
     private Long id;
     private String name;
     private String description;
-    private CategoryEntity categoryId;
+    private Long categoryId;
     private final int rooms;
     private final int bathrooms;
     private BigDecimal price;
-    private LocationEntity locationId;
+    private Long locationId;
     private LocalDate activePublicationDate;
     private PublicationStatus publicationStatus;
     private LocalDate publicationDate;
 
 
-    public PropertyModel(Long id, String name, String description, CategoryEntity categoryId,
-                         int rooms, int bathrooms, BigDecimal price, LocationEntity locationId,
+    public PropertyModel(Long id, String name, String description, Long categoryId,
+                         int rooms, int bathrooms, BigDecimal price, Long locationId,
                          LocalDate activePublicationDate, PublicationStatus publicationStatus, LocalDate publicationDate) {
         this.id = id;
         this.name = name;
@@ -64,7 +61,7 @@ public class PropertyModel {
             this.description = Objects.requireNonNull(description, FIELD_DESCRIPTION_NULL_MESSAGE);
         }
 
-        public void setCategoryId(CategoryEntity categoryId) {
+        public void setCategoryId(Long categoryId) {
             this.categoryId = Objects.requireNonNull(categoryId, FIELD_CATEGORY_NULL_MESSAGE);
         }
 
@@ -72,7 +69,7 @@ public class PropertyModel {
             this.price = Objects.requireNonNull(price, FIELD_PRICE_NULL_MESSAGE);
         }
 
-        public void setLocationId(LocationEntity locationId) {
+        public void setLocationId(Long locationId) {
             this.locationId = Objects.requireNonNull(locationId, FIELD_LOCATION_NULL_MESSAGE);
         }
 

--- a/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
@@ -45,7 +45,7 @@ public class PropertyModel {
         this.price = price;
         this.location = location;
         this.activePublicationDate = activePublicationDate;
-        this.publicationStatus = publicationStatus != null ? publicationStatus : PublicationStatus.PUBLISHING_PAUSED;
+        this.publicationStatus = PublicationStatus.PUBLISHING_PAUSED;
         this.publicationDate = LocalDate.now();
 
 

--- a/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
@@ -83,5 +83,6 @@ public class PropertyModel {
         }
 
     public void setPublicationStatus(PublicationStatus publicationStatus) {
+        this.publicationStatus = publicationStatus;
     }
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/model/PropertyModel.java
@@ -1,0 +1,88 @@
+package com.powerup.realestate.properties.domain.model;
+
+import com.powerup.realestate.properties.domain.exceptions.InvalidActivePublicationDateException;
+import com.powerup.realestate.properties.domain.exceptions.InvalidBathroomsException;
+import com.powerup.realestate.properties.domain.exceptions.InvalidRoomsException;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+
+import static com.powerup.realestate.properties.domain.utils.constants.PropertyDomainContants.*;
+
+@Getter
+@Setter
+public class PropertyModel {
+
+    private Long id;
+    private String name;
+    private String description;
+    private Long categoryId;
+    private int rooms;
+    private int bathrooms;
+    private BigDecimal price;
+    private Long locationId;
+    private LocalDate activePublicationDate;
+    private String publicationStatus;
+    private LocalDate publicationDate;
+
+
+    public PropertyModel(Long id, String name, String description, Long categoryId,
+                         int rooms, int bathrooms, BigDecimal price, Long locationId,
+                         LocalDate activePublicationDate, String publicationStatus, LocalDate publicationDate) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.categoryId = categoryId;
+        this.rooms = rooms;
+        this.bathrooms = bathrooms;
+        this.price = price;
+        this.locationId = locationId;
+        this.activePublicationDate = activePublicationDate;
+        this.publicationStatus = publicationStatus;
+        this.publicationDate = publicationDate;
+
+
+        if (rooms < 0) throw new InvalidRoomsException();
+        if (bathrooms < 0) throw new InvalidBathroomsException();
+        if (activePublicationDate != null &&  activePublicationDate.isAfter(LocalDate.now().plusMonths(1))) throw new InvalidActivePublicationDateException();
+
+    }
+
+        public void setName(String name) {
+            this.name = Objects.requireNonNull(name, FIELD_NAME_NULL_MESSAGE);
+        }
+
+        public void setDescription(String description) {
+            this.description = Objects.requireNonNull(description, FIELD_DESCRIPTION_NULL_MESSAGE);
+        }
+
+        public void setCategoryId(Long categoryId) {
+            this.categoryId = Objects.requireNonNull(categoryId, FIELD_CATEGORY_NULL_MESSAGE);
+        }
+
+        public void setPrice(BigDecimal price) {
+            this.price = Objects.requireNonNull(price, FIELD_PRICE_NULL_MESSAGE);
+        }
+
+        public void setLocationId(Long locationId) {
+            this.locationId = Objects.requireNonNull(locationId, FIELD_LOCATION_NULL_MESSAGE);
+        }
+
+        public void setActivePublicationDate(LocalDate activePublicationDate) {
+            if (activePublicationDate.isAfter(LocalDate.now().plusMonths(1))) throw new InvalidActivePublicationDateException();
+            this.activePublicationDate = Objects.requireNonNull(activePublicationDate, FIELD_ACTIVE_PUBLICATION_DATE_NULL_MESSAGE);
+        }
+
+        public void setPublicationStatus(String publicationStatus) {
+            this.publicationStatus = Objects.requireNonNull(publicationStatus, FIELD_PUBLICATION_STATUS_NULL_MESSAGE);
+        }
+
+        public void setPublicationDate(LocalDate publicationDate) {
+            this.publicationDate = Objects.requireNonNull(publicationDate, FIELD_PUBLICATION_DATE_NULL_MESSAGE);
+        }
+
+}

--- a/src/main/java/com/powerup/realestate/properties/domain/ports/in/CategoryServicePort.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/ports/in/CategoryServicePort.java
@@ -2,9 +2,11 @@ package com.powerup.realestate.properties.domain.ports.in;
 
 import com.powerup.realestate.properties.domain.model.CategoryModel;
 import com.powerup.realestate.properties.domain.utils.page.PageResult;
+import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
 
 
 public interface CategoryServicePort {
     void save(CategoryModel categoryModel);
+    CategoryModel findByCategoryId(Long categoryId);
     PageResult<CategoryModel> getCategories(Integer page, Integer size, boolean orderAsc);
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/ports/in/CategoryServicePort.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/ports/in/CategoryServicePort.java
@@ -2,11 +2,12 @@ package com.powerup.realestate.properties.domain.ports.in;
 
 import com.powerup.realestate.properties.domain.model.CategoryModel;
 import com.powerup.realestate.properties.domain.utils.page.PageResult;
-import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
+
+import java.util.Optional;
 
 
 public interface CategoryServicePort {
     void save(CategoryModel categoryModel);
-    CategoryModel findByCategoryId(Long categoryId);
+    Optional<CategoryModel> findByCategoryId(Long categoryId);
     PageResult<CategoryModel> getCategories(Integer page, Integer size, boolean orderAsc);
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/ports/in/PropertyServicePort.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/ports/in/PropertyServicePort.java
@@ -1,0 +1,10 @@
+package com.powerup.realestate.properties.domain.ports.in;
+
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+
+
+
+public interface PropertyServicePort {
+    void save(PropertyModel propertyModel);
+}
+

--- a/src/main/java/com/powerup/realestate/properties/domain/ports/out/CategoryPersistencePort.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/ports/out/CategoryPersistencePort.java
@@ -3,9 +3,12 @@ package com.powerup.realestate.properties.domain.ports.out;
 import com.powerup.realestate.properties.domain.model.CategoryModel;
 import com.powerup.realestate.properties.domain.utils.page.PageResult;
 
+import java.util.Optional;
+
 
 public interface CategoryPersistencePort {
     void save(CategoryModel categoryModel);
     CategoryModel getCategoryByName(String categoryName);
+    CategoryModel getCategoryById(Long categoryId);
     PageResult<CategoryModel> getCategories(Integer page, Integer size, boolean orderAsc);
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/ports/out/CategoryPersistencePort.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/ports/out/CategoryPersistencePort.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 public interface CategoryPersistencePort {
     void save(CategoryModel categoryModel);
     CategoryModel getCategoryByName(String categoryName);
-    CategoryModel getCategoryById(Long categoryId);
+    Optional<CategoryModel> getCategoryById(Long categoryId);
     PageResult<CategoryModel> getCategories(Integer page, Integer size, boolean orderAsc);
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/ports/out/PropertyPersistencePort.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/ports/out/PropertyPersistencePort.java
@@ -1,0 +1,9 @@
+package com.powerup.realestate.properties.domain.ports.out;
+
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+
+
+public interface PropertyPersistencePort {
+    void save(PropertyModel propertyModel);
+}
+

--- a/src/main/java/com/powerup/realestate/properties/domain/ports/out/PropertyPersistencePort.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/ports/out/PropertyPersistencePort.java
@@ -1,9 +1,14 @@
 package com.powerup.realestate.properties.domain.ports.out;
 
 import com.powerup.realestate.properties.domain.model.PropertyModel;
+import com.powerup.realestate.properties.domain.utils.PublicationStatus;
+
+import java.util.List;
 
 
 public interface PropertyPersistencePort {
     void save(PropertyModel propertyModel);
+    List<PropertyModel> findByPublicationStatus(PublicationStatus status);
+    void update(PropertyModel property);
 }
 

--- a/src/main/java/com/powerup/realestate/properties/domain/ports/out/PropertyPersistencePort.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/ports/out/PropertyPersistencePort.java
@@ -2,7 +2,6 @@ package com.powerup.realestate.properties.domain.ports.out;
 
 import com.powerup.realestate.properties.domain.model.PropertyModel;
 import com.powerup.realestate.properties.domain.utils.PublicationStatus;
-
 import java.util.List;
 
 

--- a/src/main/java/com/powerup/realestate/properties/domain/usecases/CategoryUseCase.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/usecases/CategoryUseCase.java
@@ -1,7 +1,6 @@
 package com.powerup.realestate.properties.domain.usecases;
 
 import com.powerup.realestate.properties.domain.exceptions.CategoryAlreadyExistsException;
-import com.powerup.realestate.properties.domain.exceptions.CategoryNotFoundException;
 import com.powerup.realestate.properties.domain.exceptions.DescriptionMaxSizeExceededException;
 import com.powerup.realestate.properties.domain.exceptions.NameMaxSizeExceededException;
 import com.powerup.realestate.properties.domain.model.CategoryModel;

--- a/src/main/java/com/powerup/realestate/properties/domain/usecases/CategoryUseCase.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/usecases/CategoryUseCase.java
@@ -2,10 +2,17 @@ package com.powerup.realestate.properties.domain.usecases;
 
 import com.powerup.realestate.properties.domain.exceptions.CategoryAlreadyExistsException;
 import com.powerup.realestate.properties.domain.exceptions.CategoryNotFoundException;
+import com.powerup.realestate.properties.domain.exceptions.DescriptionMaxSizeExceededException;
+import com.powerup.realestate.properties.domain.exceptions.NameMaxSizeExceededException;
 import com.powerup.realestate.properties.domain.model.CategoryModel;
 import com.powerup.realestate.properties.domain.ports.in.CategoryServicePort;
 import com.powerup.realestate.properties.domain.ports.out.CategoryPersistencePort;
 import com.powerup.realestate.properties.domain.utils.page.PageResult;
+
+import java.util.Optional;
+
+import static com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants.DESCRIPTION_MAX_CHARACTERS;
+import static com.powerup.realestate.properties.domain.utils.constants.CategoryDomainConstants.NAME_MAX_CHARACTERS;
 
 
 public class CategoryUseCase implements CategoryServicePort {
@@ -18,6 +25,12 @@ public class CategoryUseCase implements CategoryServicePort {
     @Override
     public void save(CategoryModel categoryModel) {
         CategoryModel category = categoryPersistencePort.getCategoryByName(categoryModel.getName());
+        String name = categoryModel.getName();
+        String description = categoryModel.getDescription();
+
+        if (name.length() > NAME_MAX_CHARACTERS) throw new NameMaxSizeExceededException();
+        if (description.length() > DESCRIPTION_MAX_CHARACTERS) throw new DescriptionMaxSizeExceededException();
+
         if (category != null) {
             throw new CategoryAlreadyExistsException();
         }
@@ -25,16 +38,11 @@ public class CategoryUseCase implements CategoryServicePort {
     }
 
     @Override
-    public CategoryModel findByCategoryId(Long categoryId) {
+    public Optional<CategoryModel> findByCategoryId(Long categoryId) {
         if (categoryId == null){
-            return null;
+            return Optional.empty();
         }
-        CategoryModel categoryModel = categoryPersistencePort.getCategoryById(categoryId);
-        if (categoryModel == null){
-            throw new CategoryNotFoundException();
-        }
-
-        return categoryModel;
+        return categoryPersistencePort.getCategoryById(categoryId);
     }
 
     @Override

--- a/src/main/java/com/powerup/realestate/properties/domain/usecases/CategoryUseCase.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/usecases/CategoryUseCase.java
@@ -1,6 +1,7 @@
 package com.powerup.realestate.properties.domain.usecases;
 
 import com.powerup.realestate.properties.domain.exceptions.CategoryAlreadyExistsException;
+import com.powerup.realestate.properties.domain.exceptions.CategoryNotFoundException;
 import com.powerup.realestate.properties.domain.model.CategoryModel;
 import com.powerup.realestate.properties.domain.ports.in.CategoryServicePort;
 import com.powerup.realestate.properties.domain.ports.out.CategoryPersistencePort;
@@ -21,6 +22,19 @@ public class CategoryUseCase implements CategoryServicePort {
             throw new CategoryAlreadyExistsException();
         }
         categoryPersistencePort.save(categoryModel);
+    }
+
+    @Override
+    public CategoryModel findByCategoryId(Long categoryId) {
+        if (categoryId == null){
+            return null;
+        }
+        CategoryModel categoryModel = categoryPersistencePort.getCategoryById(categoryId);
+        if (categoryModel == null){
+            throw new CategoryNotFoundException();
+        }
+
+        return categoryModel;
     }
 
     @Override

--- a/src/main/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCase.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCase.java
@@ -1,6 +1,11 @@
 package com.powerup.realestate.properties.domain.usecases;
 
+import com.powerup.realestate.commons.configurations.utils.Constants;
+import com.powerup.realestate.location.domain.ports.in.LocationServicePort;
+import com.powerup.realestate.properties.domain.exceptions.CategoryNotFoundException;
+import com.powerup.realestate.properties.domain.exceptions.LocationNotFoundException;
 import com.powerup.realestate.properties.domain.model.PropertyModel;
+import com.powerup.realestate.properties.domain.ports.in.CategoryServicePort;
 import com.powerup.realestate.properties.domain.ports.in.PropertyServicePort;
 import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
 

--- a/src/main/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCase.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCase.java
@@ -1,24 +1,55 @@
 package com.powerup.realestate.properties.domain.usecases;
 
-import com.powerup.realestate.commons.configurations.utils.Constants;
+import com.powerup.realestate.location.domain.model.LocationModel;
 import com.powerup.realestate.location.domain.ports.in.LocationServicePort;
+import com.powerup.realestate.location.domain.ports.out.LocationPersistencePort;
 import com.powerup.realestate.properties.domain.exceptions.CategoryNotFoundException;
 import com.powerup.realestate.properties.domain.exceptions.LocationNotFoundException;
+import com.powerup.realestate.properties.domain.model.CategoryModel;
 import com.powerup.realestate.properties.domain.model.PropertyModel;
 import com.powerup.realestate.properties.domain.ports.in.CategoryServicePort;
 import com.powerup.realestate.properties.domain.ports.in.PropertyServicePort;
+import com.powerup.realestate.properties.domain.ports.out.CategoryPersistencePort;
 import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
-
 
 
 public class PropertyUseCase implements PropertyServicePort {
     private final PropertyPersistencePort propertyPersistencePort;
+    private final CategoryPersistencePort categoryPersistencePort;
+    private final LocationPersistencePort locationPersistencePort;
 
-    public PropertyUseCase(PropertyPersistencePort propertyPersistencePort) {
+    public PropertyUseCase(PropertyPersistencePort propertyPersistencePort, CategoryServicePort categoryServicePort, CategoryPersistencePort categoryPersistencePort, LocationServicePort locationServicePort, LocationPersistencePort locationPersistencePort) {
         this.propertyPersistencePort = propertyPersistencePort;
+        this.categoryPersistencePort = categoryPersistencePort;
+        this.locationPersistencePort = locationPersistencePort;
     }
     @Override
     public void save(PropertyModel propertyModel) {
+        Long locationId = propertyModel.getLocationId();
+        Long categoryId = propertyModel.getCategoryId();
+
+
+        LocationModel locationModel = null;
+        if (locationId != null) {
+            locationModel = locationPersistencePort.findByLocationId(locationId);
+            if (locationModel == null) {
+                throw new LocationNotFoundException();
+            }
+        } else {
+            throw new IllegalArgumentException();
+        }
+
+        CategoryModel categoryModel = null;
+        if (categoryId != null) {
+            categoryModel = categoryPersistencePort.getCategoryById(categoryId);
+            if (categoryModel == null) {
+                throw new CategoryNotFoundException();
+            }
+        } else {
+            throw new IllegalArgumentException();
+        }
+
         propertyPersistencePort.save(propertyModel);
     }
+
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCase.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCase.java
@@ -1,54 +1,24 @@
 package com.powerup.realestate.properties.domain.usecases;
 
-import com.powerup.realestate.location.domain.model.LocationModel;
-import com.powerup.realestate.location.domain.ports.in.LocationServicePort;
-import com.powerup.realestate.location.domain.ports.out.LocationPersistencePort;
+import com.powerup.realestate.properties.application.services.PropertyValidationService;
 import com.powerup.realestate.properties.domain.exceptions.CategoryNotFoundException;
 import com.powerup.realestate.properties.domain.exceptions.LocationNotFoundException;
-import com.powerup.realestate.properties.domain.model.CategoryModel;
 import com.powerup.realestate.properties.domain.model.PropertyModel;
-import com.powerup.realestate.properties.domain.ports.in.CategoryServicePort;
 import com.powerup.realestate.properties.domain.ports.in.PropertyServicePort;
-import com.powerup.realestate.properties.domain.ports.out.CategoryPersistencePort;
 import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
 
 
 public class PropertyUseCase implements PropertyServicePort {
     private final PropertyPersistencePort propertyPersistencePort;
-    private final CategoryPersistencePort categoryPersistencePort;
-    private final LocationPersistencePort locationPersistencePort;
+    private final PropertyValidationService propertyValidationService;
 
-    public PropertyUseCase(PropertyPersistencePort propertyPersistencePort, CategoryServicePort categoryServicePort, CategoryPersistencePort categoryPersistencePort, LocationServicePort locationServicePort, LocationPersistencePort locationPersistencePort) {
+    public PropertyUseCase(PropertyPersistencePort propertyPersistencePort, PropertyValidationService propertyValidationService) {
         this.propertyPersistencePort = propertyPersistencePort;
-        this.categoryPersistencePort = categoryPersistencePort;
-        this.locationPersistencePort = locationPersistencePort;
+        this.propertyValidationService = propertyValidationService;
     }
     @Override
-    public void save(PropertyModel propertyModel) {
-        Long locationId = propertyModel.getLocationId();
-        Long categoryId = propertyModel.getCategoryId();
-
-
-        LocationModel locationModel = null;
-        if (locationId != null) {
-            locationModel = locationPersistencePort.findByLocationId(locationId);
-            if (locationModel == null) {
-                throw new LocationNotFoundException();
-            }
-        } else {
-            throw new IllegalArgumentException();
-        }
-
-        CategoryModel categoryModel = null;
-        if (categoryId != null) {
-            categoryModel = categoryPersistencePort.getCategoryById(categoryId);
-            if (categoryModel == null) {
-                throw new CategoryNotFoundException();
-            }
-        } else {
-            throw new IllegalArgumentException();
-        }
-
+    public void save(PropertyModel propertyModel) throws LocationNotFoundException, CategoryNotFoundException {
+        propertyValidationService.validate(propertyModel);
         propertyPersistencePort.save(propertyModel);
     }
 

--- a/src/main/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCase.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCase.java
@@ -1,0 +1,19 @@
+package com.powerup.realestate.properties.domain.usecases;
+
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+import com.powerup.realestate.properties.domain.ports.in.PropertyServicePort;
+import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
+
+
+
+public class PropertyUseCase implements PropertyServicePort {
+    private final PropertyPersistencePort propertyPersistencePort;
+
+    public PropertyUseCase(PropertyPersistencePort propertyPersistencePort) {
+        this.propertyPersistencePort = propertyPersistencePort;
+    }
+    @Override
+    public void save(PropertyModel propertyModel) {
+        propertyPersistencePort.save(propertyModel);
+    }
+}

--- a/src/main/java/com/powerup/realestate/properties/domain/utils/PublicationScheduler.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/utils/PublicationScheduler.java
@@ -17,11 +17,12 @@ public class PublicationScheduler {
 
     @Scheduled(fixedRate = 86400000)
     public void activatePendingPublications() {
-        List<PropertyModel> pausedProperties = propertyPersistencePort.findByPublicationStatus(PublicationStatus.PUBLISHING_PAUSED);
+        List<PropertyModel> pausedProperties = propertyPersistencePort
+                .findByPublicationStatus(PublicationStatus.PUBLISHING_PAUSED);
 
         for (PropertyModel property : pausedProperties) {
             if (property.getActivePublicationDate() != null &&
-                    !property.getActivePublicationDate().isAfter(LocalDate.now().plusDays(1))) {
+                    !property.getActivePublicationDate().isAfter(LocalDate.now())) {
 
                 property.setPublicationStatus(PublicationStatus.PUBLISHED);
                 propertyPersistencePort.update(property);

--- a/src/main/java/com/powerup/realestate/properties/domain/utils/PublicationScheduler.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/utils/PublicationScheduler.java
@@ -21,7 +21,7 @@ public class PublicationScheduler {
 
         for (PropertyModel property : pausedProperties) {
             if (property.getActivePublicationDate() != null &&
-                    !property.getActivePublicationDate().isAfter(LocalDate.now())) {
+                    !property.getActivePublicationDate().isAfter(LocalDate.now().plusDays(1))) {
 
                 property.setPublicationStatus(PublicationStatus.PUBLISHED);
                 propertyPersistencePort.update(property);

--- a/src/main/java/com/powerup/realestate/properties/domain/utils/PublicationScheduler.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/utils/PublicationScheduler.java
@@ -1,0 +1,31 @@
+package com.powerup.realestate.properties.domain.utils;
+
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PublicationScheduler {
+
+    private final PropertyPersistencePort propertyPersistencePort;
+
+    @Scheduled(fixedRate = 86400000)
+    public void activatePendingPublications() {
+        List<PropertyModel> pausedProperties = propertyPersistencePort.findByPublicationStatus(PublicationStatus.PUBLISHING_PAUSED);
+
+        for (PropertyModel property : pausedProperties) {
+            if (property.getActivePublicationDate() != null &&
+                    !property.getActivePublicationDate().isAfter(LocalDate.now())) {
+
+                property.setPublicationStatus(PublicationStatus.PUBLISHED);
+                propertyPersistencePort.update(property);
+            }
+        }
+    }
+}

--- a/src/main/java/com/powerup/realestate/properties/domain/utils/PublicationStatus.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/utils/PublicationStatus.java
@@ -1,0 +1,10 @@
+package com.powerup.realestate.properties.domain.utils;
+
+public enum PublicationStatus {
+
+    PUBLISHED,
+    PUBLISHING_PAUSED,
+    TRANSACTION_IN_PROGRESS,
+    TRANSACTION_FINALIZED
+}
+

--- a/src/main/java/com/powerup/realestate/properties/domain/utils/constants/CategoryDomainConstants.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/utils/constants/CategoryDomainConstants.java
@@ -5,8 +5,8 @@ public final class CategoryDomainConstants {
         throw new IllegalStateException("Utility class");
     }
 
-    public static final String FIELD_NAME_NULL_MESSAGE = "Field 'name' can not be null";
-    public static final String FIELD_DESCRIPTION_NULL_MESSAGE = "Field 'description' can not be null";
+    public static final String FIELD_NAME_NULL_MESSAGE = "El campo 'name' no puede estar vacío.";
+    public static final String FIELD_DESCRIPTION_NULL_MESSAGE = "El campo 'descripción' no puede estar vacío.";
     public static final int NAME_MAX_CHARACTERS = 50;
-    public static final int DESCRPTION_MAX_CHARACTERS = 90;
+    public static final int DESCRIPTION_MAX_CHARACTERS = 90;
 }

--- a/src/main/java/com/powerup/realestate/properties/domain/utils/constants/CategoryDomainConstants.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/utils/constants/CategoryDomainConstants.java
@@ -5,7 +5,7 @@ public final class CategoryDomainConstants {
         throw new IllegalStateException("Utility class");
     }
 
-    public static final String FIELD_NAME_NULL_MESSAGE = "El campo 'name' no puede estar vacío.";
+    public static final String FIELD_NAME_NULL_MESSAGE = "El campo 'nombre' no puede estar vacío.";
     public static final String FIELD_DESCRIPTION_NULL_MESSAGE = "El campo 'descripción' no puede estar vacío.";
     public static final int NAME_MAX_CHARACTERS = 50;
     public static final int DESCRIPTION_MAX_CHARACTERS = 90;

--- a/src/main/java/com/powerup/realestate/properties/domain/utils/constants/PropertyDomainContants.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/utils/constants/PropertyDomainContants.java
@@ -1,0 +1,13 @@
+package com.powerup.realestate.properties.domain.utils.constants;
+
+
+public final class PropertyDomainContants {
+    public static final String FIELD_NAME_NULL_MESSAGE = "El campo 'name' no puede estar vacío.";
+    public static final String FIELD_DESCRIPTION_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
+    public static final String FIELD_CATEGORY_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
+    public static final String FIELD_PRICE_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
+    public static final String FIELD_LOCATION_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
+    public static final String FIELD_ACTIVE_PUBLICATION_DATE_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
+    public static final String FIELD_PUBLICATION_STATUS_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
+    public static final String FIELD_PUBLICATION_DATE_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
+}

--- a/src/main/java/com/powerup/realestate/properties/domain/utils/constants/PropertyDomainContants.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/utils/constants/PropertyDomainContants.java
@@ -3,10 +3,10 @@ package com.powerup.realestate.properties.domain.utils.constants;
 
 public final class PropertyDomainContants {
     public static final String FIELD_NAME_NULL_MESSAGE = "El campo 'name' no puede estar vacío.";
-    public static final String FIELD_DESCRIPTION_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
-    public static final String FIELD_CATEGORY_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
-    public static final String FIELD_PRICE_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
-    public static final String FIELD_LOCATION_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
+    public static final String FIELD_DESCRIPTION_NULL_MESSAGE = "El campo 'descripción' no puede estar vacío.";
+    public static final String FIELD_CATEGORY_NULL_MESSAGE = "El campo 'Categoría' no puede estar vacío.";
+    public static final String FIELD_PRICE_NULL_MESSAGE = "El campo 'Precio' no puede estar vacío.";
+    public static final String FIELD_LOCATION_NULL_MESSAGE = "El campo 'Ubicación' no puede estar vacío.";
     public static final String FIELD_ACTIVE_PUBLICATION_DATE_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
     public static final String FIELD_PUBLICATION_STATUS_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";
     public static final String FIELD_PUBLICATION_DATE_NULL_MESSAGE = "El campo 'description' no puede estar vacío.";

--- a/src/main/java/com/powerup/realestate/properties/domain/utils/constants/PropertyDomainContants.java
+++ b/src/main/java/com/powerup/realestate/properties/domain/utils/constants/PropertyDomainContants.java
@@ -2,7 +2,7 @@ package com.powerup.realestate.properties.domain.utils.constants;
 
 
 public final class PropertyDomainContants {
-    public static final String FIELD_NAME_NULL_MESSAGE = "El campo 'name' no puede estar vacío.";
+    public static final String FIELD_NAME_NULL_MESSAGE = "El campo 'nombre' no puede estar vacío.";
     public static final String FIELD_DESCRIPTION_NULL_MESSAGE = "El campo 'descripción' no puede estar vacío.";
     public static final String FIELD_CATEGORY_NULL_MESSAGE = "El campo 'Categoría' no puede estar vacío.";
     public static final String FIELD_PRICE_NULL_MESSAGE = "El campo 'Precio' no puede estar vacío.";

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/adapters/persistence/CategoryPersistenceAdapter.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/adapters/persistence/CategoryPersistenceAdapter.java
@@ -35,6 +35,11 @@ public class CategoryPersistenceAdapter implements CategoryPersistencePort {
     }
 
     @Override
+    public CategoryModel getCategoryById(Long categoryId) {
+        return categoryEntityMapper.entityToModel(categoryRepository.findById(categoryId).orElse(null));
+    }
+
+    @Override
     public PageResult<CategoryModel> getCategories(Integer page, Integer size, boolean orderAsc) {
         Pageable pagination;
         if (orderAsc) pagination = PageRequest.of(page, size, Sort.by(Constants.PAGEABLE_FIELD_NAME).ascending());

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/adapters/persistence/CategoryPersistenceAdapter.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/adapters/persistence/CategoryPersistenceAdapter.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -35,8 +36,9 @@ public class CategoryPersistenceAdapter implements CategoryPersistencePort {
     }
 
     @Override
-    public CategoryModel getCategoryById(Long categoryId) {
-        return categoryEntityMapper.entityToModel(categoryRepository.findById(categoryId).orElse(null));
+    public Optional<CategoryModel> getCategoryById(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .map(categoryEntityMapper::entityToModel);
     }
 
     @Override

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/adapters/persistence/PropertyPersistenceAdapter.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/adapters/persistence/PropertyPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.powerup.realestate.properties.infrastructure.adapters.persistence;
 
 import com.powerup.realestate.properties.domain.model.PropertyModel;
 import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
+import com.powerup.realestate.properties.domain.utils.PublicationStatus;
 import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
 import com.powerup.realestate.properties.infrastructure.mappers.PropertyEntityMapper;
 import com.powerup.realestate.properties.infrastructure.repositories.mysql.PropertyRepository;
@@ -25,5 +26,19 @@ public class PropertyPersistenceAdapter implements PropertyPersistencePort {
     public void save(PropertyModel propertyModel) {
         propertyRepository.save(propertyEntityMapper.modelToEntity(propertyModel));
 
+    }
+
+    @Override
+    public List<PropertyModel> findByPublicationStatus(PublicationStatus status) {
+        List<PropertyEntity> entities = propertyRepository.findAllByPublicationStatus(status);
+        return entities.stream()
+                .map(propertyEntityMapper::entityToModel)
+                .toList();
+    }
+
+    @Override
+    public void update(PropertyModel property) {
+        PropertyEntity entity = propertyEntityMapper.modelToEntity(property);
+        propertyRepository.save(entity);
     }
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/adapters/persistence/PropertyPersistenceAdapter.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/adapters/persistence/PropertyPersistenceAdapter.java
@@ -11,8 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/adapters/persistence/PropertyPersistenceAdapter.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/adapters/persistence/PropertyPersistenceAdapter.java
@@ -1,0 +1,29 @@
+package com.powerup.realestate.properties.infrastructure.adapters.persistence;
+
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
+import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
+import com.powerup.realestate.properties.infrastructure.mappers.PropertyEntityMapper;
+import com.powerup.realestate.properties.infrastructure.repositories.mysql.PropertyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PropertyPersistenceAdapter implements PropertyPersistencePort {
+    private final PropertyRepository propertyRepository;
+    private final PropertyEntityMapper propertyEntityMapper;
+
+
+    @Override
+    public void save(PropertyModel propertyModel) {
+        propertyRepository.save(propertyEntityMapper.modelToEntity(propertyModel));
+
+    }
+}

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/endpoints/rest/PropertyController.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/endpoints/rest/PropertyController.java
@@ -3,13 +3,12 @@ package com.powerup.realestate.properties.infrastructure.endpoints.rest;
 import com.powerup.realestate.properties.application.dto.request.SavePropertyRequest;
 import com.powerup.realestate.properties.application.dto.response.SavePropertyResponse;
 import com.powerup.realestate.properties.application.services.PropertyService;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/properties")

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/endpoints/rest/PropertyController.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/endpoints/rest/PropertyController.java
@@ -1,0 +1,24 @@
+package com.powerup.realestate.properties.infrastructure.endpoints.rest;
+
+import com.powerup.realestate.properties.application.dto.request.SavePropertyRequest;
+import com.powerup.realestate.properties.application.dto.response.SavePropertyResponse;
+import com.powerup.realestate.properties.application.services.PropertyService;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/properties")
+@RequiredArgsConstructor
+public class PropertyController {
+    private final PropertyService propertyService;
+
+    @PostMapping("/")
+    public ResponseEntity<SavePropertyResponse> save(@RequestBody SavePropertyRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(propertyService.save(request));
+    }
+}

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/entities/CategoryEntity.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/entities/CategoryEntity.java
@@ -1,12 +1,10 @@
 package com.powerup.realestate.properties.infrastructure.entities;
 
-import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
+
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Entity
 @Data

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/entities/CategoryEntity.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/entities/CategoryEntity.java
@@ -1,12 +1,12 @@
 package com.powerup.realestate.properties.infrastructure.entities;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Data
@@ -18,4 +18,6 @@ public class CategoryEntity {
     private Long id;
     private String name;
     private String description;
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<PropertyEntity> properties;
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/entities/CategoryEntity.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/entities/CategoryEntity.java
@@ -18,6 +18,5 @@ public class CategoryEntity {
     private Long id;
     private String name;
     private String description;
-    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<PropertyEntity> properties;
+
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/entities/PropertyEntity.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/entities/PropertyEntity.java
@@ -1,5 +1,6 @@
 package com.powerup.realestate.properties.infrastructure.entities;
 
+import com.powerup.realestate.properties.domain.utils.PublicationStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,7 +25,8 @@ public class PropertyEntity {
         private BigDecimal price;
         private Long locationId;
         private LocalDate activePublicationDate;
-        private String publicationStatus;
+        @Enumerated(EnumType.STRING)
+        private PublicationStatus publicationStatus;
         private LocalDate publicationDate;
 
     }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/entities/PropertyEntity.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/entities/PropertyEntity.java
@@ -1,5 +1,6 @@
 package com.powerup.realestate.properties.infrastructure.entities;
 
+import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
 import com.powerup.realestate.properties.domain.utils.PublicationStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -19,15 +20,20 @@ public class PropertyEntity {
         private Long id;
         private String name;
         private String description;
-        private Long categoryId;
         private int rooms;
         private int bathrooms;
         private BigDecimal price;
-        private Long locationId;
         private LocalDate activePublicationDate;
         @Enumerated(EnumType.STRING)
         private PublicationStatus publicationStatus;
         private LocalDate publicationDate;
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "category_id", nullable = false)
+        private CategoryEntity category;
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "location_id", nullable = false)
+        private LocationEntity location;
+
 
     }
 

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/entities/PropertyEntity.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/entities/PropertyEntity.java
@@ -1,0 +1,31 @@
+package com.powerup.realestate.properties.infrastructure.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PropertyEntity {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+        private String name;
+        private String description;
+        private Long categoryId;
+        private int rooms;
+        private int bathrooms;
+        private BigDecimal price;
+        private Long locationId;
+        private LocalDate activePublicationDate;
+        private String publicationStatus;
+        private LocalDate publicationDate;
+
+    }
+

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/exceptionshandler/ControllerAdvisor.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/exceptionshandler/ControllerAdvisor.java
@@ -1,8 +1,6 @@
 package com.powerup.realestate.properties.infrastructure.exceptionshandler;
 
-import com.powerup.realestate.properties.domain.exceptions.CategoryAlreadyExistsException;
-import com.powerup.realestate.properties.domain.exceptions.DescriptionMaxSizeExceededException;
-import com.powerup.realestate.properties.domain.exceptions.NameMaxSizeExceededException;
+import com.powerup.realestate.properties.domain.exceptions.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,6 +24,18 @@ public class ControllerAdvisor {
     @ExceptionHandler(CategoryAlreadyExistsException.class)
     public ResponseEntity<ExceptionResponse> handleCategoryAlreadyExistsException(CategoryAlreadyExistsException exception) {
         return ResponseEntity.badRequest().body(new ExceptionResponse(ExceptionConstants.CATEGORY_EXISTS_EXCEPTION,
+                LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(CategoryNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleCategoryNotFoundException(CategoryNotFoundException exception) {
+        return ResponseEntity.badRequest().body(new ExceptionResponse(ExceptionConstants.CATEGORY_NON_EXISTS_EXCEPTION,
+                LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(LocationNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleLocationNotFoundException(LocationNotFoundException exception) {
+        return ResponseEntity.badRequest().body(new ExceptionResponse(ExceptionConstants.LOCATION_NON_EXISTS_EXCEPTION,
                 LocalDateTime.now()));
     }
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/exceptionshandler/ExceptionConstants.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/exceptionshandler/ExceptionConstants.java
@@ -3,7 +3,9 @@ package com.powerup.realestate.properties.infrastructure.exceptionshandler;
 public final class ExceptionConstants {
     private ExceptionConstants(){}
 
-    public static final String NAME_MAX_SIZE_MESSAGE = "The name of the category can not exceed 50 characters";
-    public static final String DESCRIPTION_MAX_SIZE_MESSAGE = "The description of the category can not exceed 90 characters";
-    public static final String CATEGORY_EXISTS_EXCEPTION = "The category already exists";
+    public static final String NAME_MAX_SIZE_MESSAGE = "El nombre de la categoría no puede exceder los 50 caracteres";
+    public static final String DESCRIPTION_MAX_SIZE_MESSAGE = "La descripción de la categoría no puede exceder los 90 caracteres";
+    public static final String CATEGORY_EXISTS_EXCEPTION = "La categoría ya existe";
+    public static final String CATEGORY_NON_EXISTS_EXCEPTION = "Categoría no existe";
+    public static final String LOCATION_NON_EXISTS_EXCEPTION = "Ubicación no existe";
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/mappers/PropertyEntityMapper.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/mappers/PropertyEntityMapper.java
@@ -1,0 +1,15 @@
+package com.powerup.realestate.properties.infrastructure.mappers;
+
+import com.powerup.realestate.properties.domain.model.CategoryModel;
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
+import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+@Mapper(componentModel = "spring")
+public interface PropertyEntityMapper {
+    PropertyEntity modelToEntity(PropertyModel propertyModel);
+    PropertyModel entityToModel(PropertyEntity propertyEntity);
+    List<PropertyModel> entityListToModelList(List<PropertyEntity> properties);
+}

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/mappers/PropertyEntityMapper.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/mappers/PropertyEntityMapper.java
@@ -1,52 +1,18 @@
 package com.powerup.realestate.properties.infrastructure.mappers;
 
-import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
-import com.powerup.realestate.properties.domain.model.CategoryModel;
+
+import com.powerup.realestate.location.infrastructure.mappers.LocationEntityMapper;
 import com.powerup.realestate.properties.domain.model.PropertyModel;
-import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
 import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 
 import java.util.List;
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring",
+        uses = {CategoryEntityMapper.class, LocationEntityMapper.class})
 public interface PropertyEntityMapper {
-    @Mapping(source = "locationId", target = "location", qualifiedByName = "mapLocationIdToEntity")
-    @Mapping(source = "categoryId", target = "category", qualifiedByName = "mapCategoryIdToEntity")
+
     PropertyEntity modelToEntity(PropertyModel propertyModel);
-    @Mapping(source = "location", target = "locationId", qualifiedByName = "mapLocationEntityToId")
-    @Mapping(source = "category", target = "categoryId", qualifiedByName = "mapCategoryEntityToId")
     PropertyModel entityToModel(PropertyEntity propertyEntity);
     List<PropertyModel> entityListToModelList(List<PropertyEntity> properties);
 
-    @Named("mapLocationIdToEntity")
-    default LocationEntity mapLocationIdToEntity(Long locationId) {
-        if (locationId == null) {
-            return null;
-        }
-        LocationEntity locationEntity = new LocationEntity();
-        locationEntity.setId(locationId);
-        return locationEntity;
-    }
-
-    @Named("mapCategoryIdToEntity")
-    default CategoryEntity mapCategoryIdToEntity(Long categoryId) {
-        if (categoryId == null) {
-            return null;
-        }
-        CategoryEntity categoryEntity = new CategoryEntity();
-        categoryEntity.setId(categoryId);
-        return categoryEntity;
-    }
-
-    @Named("mapLocationEntityToId")
-    default Long mapLocationEntityToId(LocationEntity locationEntity) {
-        return locationEntity != null ? locationEntity.getId() : null;
-    }
-
-    @Named("mapCategoryEntityToId")
-    default Long mapCategoryEntityToId(CategoryEntity categoryEntity) {
-        return categoryEntity != null ? categoryEntity.getId() : null;
-    }
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/mappers/PropertyEntityMapper.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/mappers/PropertyEntityMapper.java
@@ -1,20 +1,52 @@
 package com.powerup.realestate.properties.infrastructure.mappers;
 
+import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
 import com.powerup.realestate.properties.domain.model.CategoryModel;
 import com.powerup.realestate.properties.domain.model.PropertyModel;
 import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
 import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 import java.util.List;
 @Mapper(componentModel = "spring")
 public interface PropertyEntityMapper {
-    @Mapping(source = "locationId", target = "location")
-    @Mapping(source = "categoryId", target = "category")
+    @Mapping(source = "locationId", target = "location", qualifiedByName = "mapLocationIdToEntity")
+    @Mapping(source = "categoryId", target = "category", qualifiedByName = "mapCategoryIdToEntity")
     PropertyEntity modelToEntity(PropertyModel propertyModel);
-    @Mapping(source = "location", target = "locationId")
-    @Mapping(source = "category", target = "categoryId")
+    @Mapping(source = "location", target = "locationId", qualifiedByName = "mapLocationEntityToId")
+    @Mapping(source = "category", target = "categoryId", qualifiedByName = "mapCategoryEntityToId")
     PropertyModel entityToModel(PropertyEntity propertyEntity);
     List<PropertyModel> entityListToModelList(List<PropertyEntity> properties);
+
+    @Named("mapLocationIdToEntity")
+    default LocationEntity mapLocationIdToEntity(Long locationId) {
+        if (locationId == null) {
+            return null;
+        }
+        LocationEntity locationEntity = new LocationEntity();
+        locationEntity.setId(locationId);
+        return locationEntity;
+    }
+
+    @Named("mapCategoryIdToEntity")
+    default CategoryEntity mapCategoryIdToEntity(Long categoryId) {
+        if (categoryId == null) {
+            return null;
+        }
+        CategoryEntity categoryEntity = new CategoryEntity();
+        categoryEntity.setId(categoryId);
+        return categoryEntity;
+    }
+
+    @Named("mapLocationEntityToId")
+    default Long mapLocationEntityToId(LocationEntity locationEntity) {
+        return locationEntity != null ? locationEntity.getId() : null;
+    }
+
+    @Named("mapCategoryEntityToId")
+    default Long mapCategoryEntityToId(CategoryEntity categoryEntity) {
+        return categoryEntity != null ? categoryEntity.getId() : null;
+    }
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/mappers/PropertyEntityMapper.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/mappers/PropertyEntityMapper.java
@@ -5,11 +5,16 @@ import com.powerup.realestate.properties.domain.model.PropertyModel;
 import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
 import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.List;
 @Mapper(componentModel = "spring")
 public interface PropertyEntityMapper {
+    @Mapping(source = "locationId", target = "location")
+    @Mapping(source = "categoryId", target = "category")
     PropertyEntity modelToEntity(PropertyModel propertyModel);
+    @Mapping(source = "location", target = "locationId")
+    @Mapping(source = "category", target = "categoryId")
     PropertyModel entityToModel(PropertyEntity propertyEntity);
     List<PropertyModel> entityListToModelList(List<PropertyEntity> properties);
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/repositories/mysql/CategoryRepository.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/repositories/mysql/CategoryRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
     Optional<CategoryEntity> findByName(String name);
-    Page<CategoryEntity> findAll(Pageable pageable);
     Optional<CategoryEntity> findById(Long categoryId);
+    Page<CategoryEntity> findAll(Pageable pageable);
 
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/repositories/mysql/CategoryRepository.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/repositories/mysql/CategoryRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
     Optional<CategoryEntity> findByName(String name);
     Page<CategoryEntity> findAll(Pageable pageable);
+    Optional<CategoryEntity> findById(Long categoryId);
+
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/repositories/mysql/PropertyRepository.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/repositories/mysql/PropertyRepository.java
@@ -1,7 +1,11 @@
 package com.powerup.realestate.properties.infrastructure.repositories.mysql;
 
+import com.powerup.realestate.properties.domain.utils.PublicationStatus;
 import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PropertyRepository extends JpaRepository<PropertyEntity, Long> {
+    List<PropertyEntity> findAllByPublicationStatus(PublicationStatus status);
 }

--- a/src/main/java/com/powerup/realestate/properties/infrastructure/repositories/mysql/PropertyRepository.java
+++ b/src/main/java/com/powerup/realestate/properties/infrastructure/repositories/mysql/PropertyRepository.java
@@ -1,0 +1,7 @@
+package com.powerup.realestate.properties.infrastructure.repositories.mysql;
+
+import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PropertyRepository extends JpaRepository<PropertyEntity, Long> {
+}

--- a/src/test/java/com/powerup/realestate/location/domain/usecases/LocationUseCaseTest.java
+++ b/src/test/java/com/powerup/realestate/location/domain/usecases/LocationUseCaseTest.java
@@ -1,6 +1,5 @@
 package com.powerup.realestate.location.domain.usecases;
 
-import com.powerup.realestate.location.domain.exceptions.CityNonExistentException;
 import com.powerup.realestate.location.domain.model.LocationModel;
 import com.powerup.realestate.location.domain.ports.in.CityServicePort;
 import com.powerup.realestate.location.domain.ports.out.LocationPersistencePort;

--- a/src/test/java/com/powerup/realestate/properties/domain/model/CategoryModelTest.java
+++ b/src/test/java/com/powerup/realestate/properties/domain/model/CategoryModelTest.java
@@ -1,11 +1,7 @@
 package com.powerup.realestate.properties.domain.model;
 
-import com.powerup.realestate.properties.domain.exceptions.DescriptionMaxSizeExceededException;
-import com.powerup.realestate.properties.domain.exceptions.NameMaxSizeExceededException;
 import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class CategoryModelTest {
 
@@ -38,22 +34,6 @@ class CategoryModelTest {
     }
 
     @Test
-    void shouldCreateCategoryWhenNameExceeds50Characters() {
-        String invalidName= "n".repeat(51);
-        String validDescription = "description";
-
-        assertThrows(NameMaxSizeExceededException.class,() ->  new CategoryModel(1L,invalidName,validDescription));
-    }
-    @Test
-    void shouldThrowExceptionWhenDescriptionExceeds90Characters() {
-        String validName = "name";
-        String longDescription = "d".repeat(91);
-
-        assertThrows(DescriptionMaxSizeExceededException.class,
-                () -> new CategoryModel(1L, validName, longDescription)
-        );
-    }
-    @Test
     void shouldSetNameWithinLimit() {
         CategoryModel category = new CategoryModel(1L,"ValidName","Valid Description");
         String validName= "n".repeat(50);
@@ -63,31 +43,12 @@ class CategoryModelTest {
     }
 
     @Test
-    void shouldNotCallGetNameWhenNameExceedsLimit() {
-
-        CategoryModel categorySpy = spy(new CategoryModel(1L, "ValidName", "ValidDescription"));
-        String invalidName = "n".repeat(51);
-
-        assertThrows(NameMaxSizeExceededException.class, () -> categorySpy.setName(invalidName));
-
-        verify(categorySpy, never()).getName();
-    }
-    @Test
     void shouldSetDescriptionWithinLimit() {
         CategoryModel category = new CategoryModel(1L,"ValidName","ValidDescription");
         String validDescription = "d".repeat(90);
 
         assertDoesNotThrow(() -> category.setDescription(validDescription));
         assertEquals(validDescription, category.getDescription());
-    }
-    @Test
-    void shouldNotSetDescriptionExceedsLimit() {
-        CategoryModel categorySpy =spy(new CategoryModel(1L, "ValidName","ValidDescription"));
-        String invalidDescription="d".repeat(91);
-
-        assertThrows(DescriptionMaxSizeExceededException.class,()-> categorySpy.setDescription(invalidDescription));
-        verify(categorySpy, never()).getDescription();
-
     }
 
 }

--- a/src/test/java/com/powerup/realestate/properties/domain/model/PropertyModelTest.java
+++ b/src/test/java/com/powerup/realestate/properties/domain/model/PropertyModelTest.java
@@ -1,22 +1,17 @@
 package com.powerup.realestate.properties.domain.model;
 
-import com.powerup.realestate.location.infrastructure.entities.CityEntity;
-import com.powerup.realestate.location.infrastructure.entities.DepartmentEntity;
-import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
+
 import com.powerup.realestate.properties.domain.exceptions.InvalidActivePublicationDateException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidBathroomsException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidRoomsException;
 import com.powerup.realestate.properties.domain.utils.PublicationStatus;
 import com.powerup.realestate.properties.domain.utils.constants.PropertyDomainContants;
-import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
-import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
+
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -25,28 +20,25 @@ class PropertyModelTest {
     private Long id;
     private String name;
     private String description;
-    private CategoryEntity categoryId;
+    private Long categoryId;
     private int rooms;
     private int bathrooms;
     private BigDecimal price;
-    private LocationEntity locationId;
+    private Long locationId;
     private LocalDate activePublicationDate;
     private PublicationStatus publicationStatus;
     private LocalDate publicationDate;
-    DepartmentEntity department = new DepartmentEntity(1L, "Nombre del Departamento", "Descripción del Departamento", null);
-    List<LocationEntity> locations = new ArrayList<>();
-    CityEntity city = new CityEntity(1L, "Cúcuta", "Ciudad principal", department, locations);
 
     @BeforeEach
     void setUp() {
         id = 1L;
         name = "Beautiful House";
         description = "A spacious and modern house";
-        categoryId = new CategoryEntity(1L,"ciudad", "descripcion ciudad");
+        categoryId = 1L;
         rooms = 3;
         bathrooms = 2;
         price = BigDecimal.valueOf(250000);
-        locationId = new LocationEntity(1L,"Ubicacion",city );
+        locationId = 2L;
         activePublicationDate = LocalDate.now();
         publicationStatus = PublicationStatus.PUBLISHED;
         publicationDate = LocalDate.now();
@@ -54,7 +46,9 @@ class PropertyModelTest {
 
     @Test
     void shouldCreatePropertySuccessfully() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property =
+                new PropertyModel(id, name, description, categoryId, rooms, bathrooms,
+                        price, locationId, activePublicationDate, publicationStatus, publicationDate);
 
         assertEquals(name, property.getName());
         assertEquals(description, property.getDescription());
@@ -69,65 +63,80 @@ class PropertyModelTest {
     }
     @Test
     void shouldThrowExceptionWhenRoomsAreNegative() {
-        assertThrows(InvalidRoomsException.class, () -> new PropertyModel(id, name, description, categoryId, -1, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate));
+        assertThrows(InvalidRoomsException.class, () ->
+                new PropertyModel(id, name, description, categoryId, -1,
+                        bathrooms, price, locationId, activePublicationDate,
+                        publicationStatus, publicationDate));
     }
 
     @Test
     void shouldThrowExceptionWhenBathroomsAreNegative() {
-        assertThrows(InvalidBathroomsException.class, () -> new PropertyModel(id, name, description, categoryId, rooms, -1, price, locationId, activePublicationDate, publicationStatus, publicationDate));
+        assertThrows(InvalidBathroomsException.class, () ->
+                new PropertyModel(id, name, description, categoryId, rooms, -1,
+                        price, locationId, activePublicationDate,
+                        publicationStatus, publicationDate));
     }
 
     @Test
     void shouldThrowExceptionWhenActivePublicationDateIsTooFarInFuture() {
         LocalDate futureDate = LocalDate.now().plusMonths(2);
-        assertThrows(InvalidActivePublicationDateException.class, () -> new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, futureDate, publicationStatus, publicationDate));
+        assertThrows(InvalidActivePublicationDateException.class, () ->
+                new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId,
+                        futureDate, publicationStatus, publicationDate));
     }
 
     @Test
     void shouldThrowExceptionWhenNameIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
+                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setName(null));
         assertEquals(PropertyDomainContants.FIELD_NAME_NULL_MESSAGE, exception.getMessage());
     }
 
     @Test
     void shouldThrowExceptionWhenDescriptionIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
+                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setDescription(null));
         assertEquals(PropertyDomainContants.FIELD_DESCRIPTION_NULL_MESSAGE, exception.getMessage());
     }
 
     @Test
     void shouldThrowExceptionWhenCategoryIdIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
+                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setCategoryId(null));
         assertEquals(PropertyDomainContants.FIELD_CATEGORY_NULL_MESSAGE, exception.getMessage());
     }
 
     @Test
     void shouldThrowExceptionWhenPriceIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
+                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setPrice(null));
         assertEquals(PropertyDomainContants.FIELD_PRICE_NULL_MESSAGE, exception.getMessage());
     }
 
     @Test
     void shouldThrowExceptionWhenLocationIdIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
+                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setLocationId(null));
         assertEquals(PropertyDomainContants.FIELD_LOCATION_NULL_MESSAGE, exception.getMessage());
     }
 
     @Test
     void shouldThrowExceptionWhenPublicationStatusIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
+                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setPublicationStatus(null));
         assertEquals(PropertyDomainContants.FIELD_PUBLICATION_STATUS_NULL_MESSAGE, exception.getMessage());
     }
 
     @Test
     void shouldThrowExceptionWhenPublicationDateIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
+                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setPublicationDate(null));
         assertEquals(PropertyDomainContants.FIELD_PUBLICATION_DATE_NULL_MESSAGE, exception.getMessage());
     }

--- a/src/test/java/com/powerup/realestate/properties/domain/model/PropertyModelTest.java
+++ b/src/test/java/com/powerup/realestate/properties/domain/model/PropertyModelTest.java
@@ -1,0 +1,125 @@
+package com.powerup.realestate.properties.domain.model;
+
+import com.powerup.realestate.properties.domain.exceptions.InvalidActivePublicationDateException;
+import com.powerup.realestate.properties.domain.exceptions.InvalidBathroomsException;
+import com.powerup.realestate.properties.domain.exceptions.InvalidRoomsException;
+import com.powerup.realestate.properties.domain.utils.PublicationStatus;
+import com.powerup.realestate.properties.domain.utils.constants.PropertyDomainContants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PropertyModelTest {
+
+    private Long id;
+    private String name;
+    private String description;
+    private Long categoryId;
+    private int rooms;
+    private int bathrooms;
+    private BigDecimal price;
+    private Long locationId;
+    private LocalDate activePublicationDate;
+    private PublicationStatus publicationStatus;
+    private LocalDate publicationDate;
+
+    @BeforeEach
+    void setUp() {
+        id = 1L;
+        name = "Beautiful House";
+        description = "A spacious and modern house";
+        categoryId = 101L;
+        rooms = 3;
+        bathrooms = 2;
+        price = BigDecimal.valueOf(250000);
+        locationId = 1001L;
+        activePublicationDate = LocalDate.now();
+        publicationStatus = PublicationStatus.PUBLISHED;
+        publicationDate = LocalDate.now();
+    }
+
+    @Test
+    void shouldCreatePropertySuccessfully() {
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+
+        assertEquals(name, property.getName());
+        assertEquals(description, property.getDescription());
+        assertEquals(categoryId, property.getCategoryId());
+        assertEquals(rooms, property.getRooms());
+        assertEquals(bathrooms, property.getBathrooms());
+        assertEquals(price, property.getPrice());
+        assertEquals(locationId, property.getLocationId());
+        assertEquals(activePublicationDate, property.getActivePublicationDate());
+        assertEquals(publicationStatus, property.getPublicationStatus());
+        assertEquals(publicationDate, property.getPublicationDate());
+    }
+    @Test
+    void shouldThrowExceptionWhenRoomsAreNegative() {
+        assertThrows(InvalidRoomsException.class, () -> new PropertyModel(id, name, description, categoryId, -1, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenBathroomsAreNegative() {
+        assertThrows(InvalidBathroomsException.class, () -> new PropertyModel(id, name, description, categoryId, rooms, -1, price, locationId, activePublicationDate, publicationStatus, publicationDate));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenActivePublicationDateIsTooFarInFuture() {
+        LocalDate futureDate = LocalDate.now().plusMonths(2);
+        assertThrows(InvalidActivePublicationDateException.class, () -> new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, futureDate, publicationStatus, publicationDate));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNameIsNull() {
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setName(null));
+        assertEquals(PropertyDomainContants.FIELD_NAME_NULL_MESSAGE, exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDescriptionIsNull() {
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setDescription(null));
+        assertEquals(PropertyDomainContants.FIELD_DESCRIPTION_NULL_MESSAGE, exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCategoryIdIsNull() {
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setCategoryId(null));
+        assertEquals(PropertyDomainContants.FIELD_CATEGORY_NULL_MESSAGE, exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenPriceIsNull() {
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setPrice(null));
+        assertEquals(PropertyDomainContants.FIELD_PRICE_NULL_MESSAGE, exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenLocationIdIsNull() {
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setLocationId(null));
+        assertEquals(PropertyDomainContants.FIELD_LOCATION_NULL_MESSAGE, exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenPublicationStatusIsNull() {
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setPublicationStatus(null));
+        assertEquals(PropertyDomainContants.FIELD_PUBLICATION_STATUS_NULL_MESSAGE, exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenPublicationDateIsNull() {
+        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setPublicationDate(null));
+        assertEquals(PropertyDomainContants.FIELD_PUBLICATION_DATE_NULL_MESSAGE, exception.getMessage());
+    }
+
+}

--- a/src/test/java/com/powerup/realestate/properties/domain/model/PropertyModelTest.java
+++ b/src/test/java/com/powerup/realestate/properties/domain/model/PropertyModelTest.java
@@ -1,6 +1,9 @@
 package com.powerup.realestate.properties.domain.model;
 
 
+import com.powerup.realestate.location.domain.model.LocationModel;
+import com.powerup.realestate.location.infrastructure.entities.CityEntity;
+import com.powerup.realestate.location.infrastructure.entities.DepartmentEntity;
 import com.powerup.realestate.properties.domain.exceptions.InvalidActivePublicationDateException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidBathroomsException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidRoomsException;
@@ -20,25 +23,44 @@ class PropertyModelTest {
     private Long id;
     private String name;
     private String description;
-    private Long categoryId;
+    private CategoryModel category;
     private int rooms;
     private int bathrooms;
     private BigDecimal price;
-    private Long locationId;
+    private LocationModel location;
     private LocalDate activePublicationDate;
     private PublicationStatus publicationStatus;
     private LocalDate publicationDate;
+
+    DepartmentEntity department = DepartmentEntity.builder()
+            .id(1L)
+            .name("Norte de Santander")
+            .build();
+
+    CityEntity city = CityEntity.builder()
+            .id(1L)
+            .name("Cucuta")
+            .departmentEntity(department)
+            .build();
 
     @BeforeEach
     void setUp() {
         id = 1L;
         name = "Beautiful House";
         description = "A spacious and modern house";
-        categoryId = 1L;
+        category = CategoryModel.builder()
+                .id(1L)
+                .name("House")
+                .description("Residential house")
+                .build();
         rooms = 3;
         bathrooms = 2;
         price = BigDecimal.valueOf(250000);
-        locationId = 2L;
+        location = LocationModel.builder()
+                .id(2L)
+                .neighborhood("Downtown")
+                .cityName(city)
+                .build();
         activePublicationDate = LocalDate.now();
         publicationStatus = PublicationStatus.PUBLISHED;
         publicationDate = LocalDate.now();
@@ -47,33 +69,32 @@ class PropertyModelTest {
     @Test
     void shouldCreatePropertySuccessfully() {
         PropertyModel property =
-                new PropertyModel(id, name, description, categoryId, rooms, bathrooms,
-                        price, locationId, activePublicationDate, publicationStatus, publicationDate);
+                new PropertyModel(id, name, description, category, rooms, bathrooms,
+                        price, location, activePublicationDate, publicationStatus, publicationDate);
 
         assertEquals(name, property.getName());
         assertEquals(description, property.getDescription());
-        assertEquals(categoryId, property.getCategoryId());
+        assertEquals(category, property.getCategory());
         assertEquals(rooms, property.getRooms());
         assertEquals(bathrooms, property.getBathrooms());
         assertEquals(price, property.getPrice());
-        assertEquals(locationId, property.getLocationId());
+        assertEquals(location, property.getLocation());
         assertEquals(activePublicationDate, property.getActivePublicationDate());
-        assertEquals(publicationStatus, property.getPublicationStatus());
-        assertEquals(publicationDate, property.getPublicationDate());
+        assertEquals(publicationDate, LocalDate.now());
     }
     @Test
     void shouldThrowExceptionWhenRoomsAreNegative() {
         assertThrows(InvalidRoomsException.class, () ->
-                new PropertyModel(id, name, description, categoryId, -1,
-                        bathrooms, price, locationId, activePublicationDate,
+                new PropertyModel(id, name, description, category, -1,
+                        bathrooms, price, location, activePublicationDate,
                         publicationStatus, publicationDate));
     }
 
     @Test
     void shouldThrowExceptionWhenBathroomsAreNegative() {
         assertThrows(InvalidBathroomsException.class, () ->
-                new PropertyModel(id, name, description, categoryId, rooms, -1,
-                        price, locationId, activePublicationDate,
+                new PropertyModel(id, name, description, category, rooms, -1,
+                        price, location, activePublicationDate,
                         publicationStatus, publicationDate));
     }
 
@@ -81,62 +102,39 @@ class PropertyModelTest {
     void shouldThrowExceptionWhenActivePublicationDateIsTooFarInFuture() {
         LocalDate futureDate = LocalDate.now().plusMonths(2);
         assertThrows(InvalidActivePublicationDateException.class, () ->
-                new PropertyModel(id, name, description, categoryId, rooms, bathrooms, price, locationId,
+                new PropertyModel(id, name, description, category, rooms, bathrooms, price, location,
                         futureDate, publicationStatus, publicationDate));
     }
 
     @Test
     void shouldThrowExceptionWhenNameIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
-                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, category, rooms,
+                bathrooms, price, location, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setName(null));
         assertEquals(PropertyDomainContants.FIELD_NAME_NULL_MESSAGE, exception.getMessage());
     }
 
     @Test
     void shouldThrowExceptionWhenDescriptionIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
-                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, category, rooms,
+                bathrooms, price, location, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setDescription(null));
         assertEquals(PropertyDomainContants.FIELD_DESCRIPTION_NULL_MESSAGE, exception.getMessage());
     }
 
     @Test
-    void shouldThrowExceptionWhenCategoryIdIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
-                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
-        NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setCategoryId(null));
-        assertEquals(PropertyDomainContants.FIELD_CATEGORY_NULL_MESSAGE, exception.getMessage());
-    }
-
-    @Test
     void shouldThrowExceptionWhenPriceIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
-                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, category, rooms,
+                bathrooms, price, location, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setPrice(null));
         assertEquals(PropertyDomainContants.FIELD_PRICE_NULL_MESSAGE, exception.getMessage());
     }
 
-    @Test
-    void shouldThrowExceptionWhenLocationIdIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
-                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
-        NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setLocationId(null));
-        assertEquals(PropertyDomainContants.FIELD_LOCATION_NULL_MESSAGE, exception.getMessage());
-    }
-
-    @Test
-    void shouldThrowExceptionWhenPublicationStatusIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
-                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
-        NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setPublicationStatus(null));
-        assertEquals(PropertyDomainContants.FIELD_PUBLICATION_STATUS_NULL_MESSAGE, exception.getMessage());
-    }
 
     @Test
     void shouldThrowExceptionWhenPublicationDateIsNull() {
-        PropertyModel property = new PropertyModel(id, name, description, categoryId, rooms,
-                bathrooms, price, locationId, activePublicationDate, publicationStatus, publicationDate);
+        PropertyModel property = new PropertyModel(id, name, description, category, rooms,
+                bathrooms, price, location, activePublicationDate, publicationStatus, publicationDate);
         NullPointerException exception = assertThrows(NullPointerException.class, () -> property.setPublicationDate(null));
         assertEquals(PropertyDomainContants.FIELD_PUBLICATION_DATE_NULL_MESSAGE, exception.getMessage());
     }

--- a/src/test/java/com/powerup/realestate/properties/domain/model/PropertyModelTest.java
+++ b/src/test/java/com/powerup/realestate/properties/domain/model/PropertyModelTest.java
@@ -1,15 +1,22 @@
 package com.powerup.realestate.properties.domain.model;
 
+import com.powerup.realestate.location.infrastructure.entities.CityEntity;
+import com.powerup.realestate.location.infrastructure.entities.DepartmentEntity;
+import com.powerup.realestate.location.infrastructure.entities.LocationEntity;
 import com.powerup.realestate.properties.domain.exceptions.InvalidActivePublicationDateException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidBathroomsException;
 import com.powerup.realestate.properties.domain.exceptions.InvalidRoomsException;
 import com.powerup.realestate.properties.domain.utils.PublicationStatus;
 import com.powerup.realestate.properties.domain.utils.constants.PropertyDomainContants;
+import com.powerup.realestate.properties.infrastructure.entities.CategoryEntity;
+import com.powerup.realestate.properties.infrastructure.entities.PropertyEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -18,25 +25,28 @@ class PropertyModelTest {
     private Long id;
     private String name;
     private String description;
-    private Long categoryId;
+    private CategoryEntity categoryId;
     private int rooms;
     private int bathrooms;
     private BigDecimal price;
-    private Long locationId;
+    private LocationEntity locationId;
     private LocalDate activePublicationDate;
     private PublicationStatus publicationStatus;
     private LocalDate publicationDate;
+    DepartmentEntity department = new DepartmentEntity(1L, "Nombre del Departamento", "Descripción del Departamento", null);
+    List<LocationEntity> locations = new ArrayList<>();
+    CityEntity city = new CityEntity(1L, "Cúcuta", "Ciudad principal", department, locations);
 
     @BeforeEach
     void setUp() {
         id = 1L;
         name = "Beautiful House";
         description = "A spacious and modern house";
-        categoryId = 101L;
+        categoryId = new CategoryEntity(1L,"ciudad", "descripcion ciudad");
         rooms = 3;
         bathrooms = 2;
         price = BigDecimal.valueOf(250000);
-        locationId = 1001L;
+        locationId = new LocationEntity(1L,"Ubicacion",city );
         activePublicationDate = LocalDate.now();
         publicationStatus = PublicationStatus.PUBLISHED;
         publicationDate = LocalDate.now();

--- a/src/test/java/com/powerup/realestate/properties/domain/usecases/CategoryUseCaseTest.java
+++ b/src/test/java/com/powerup/realestate/properties/domain/usecases/CategoryUseCaseTest.java
@@ -9,9 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
 import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -87,4 +85,5 @@ class CategoryUseCaseTest {
          verify(categoryPersistencePort).getCategories(page, size, orderAsc);
          assertEquals(pageResultMock, paginatedCategoryList);
      }
+
 }

--- a/src/test/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCaseTest.java
+++ b/src/test/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCaseTest.java
@@ -1,0 +1,98 @@
+package com.powerup.realestate.properties.domain.usecases;
+
+import com.powerup.realestate.location.domain.model.LocationModel;
+import com.powerup.realestate.location.domain.ports.out.LocationPersistencePort;
+import com.powerup.realestate.properties.domain.exceptions.CategoryNotFoundException;
+import com.powerup.realestate.properties.domain.exceptions.LocationNotFoundException;
+import com.powerup.realestate.properties.domain.model.CategoryModel;
+import com.powerup.realestate.properties.domain.model.PropertyModel;
+import com.powerup.realestate.properties.domain.ports.out.CategoryPersistencePort;
+import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
+import com.powerup.realestate.properties.domain.utils.PublicationStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PropertyUseCaseTest {
+
+    @Mock
+    private PropertyPersistencePort propertyPersistencePort;
+
+    @Mock
+    private LocationPersistencePort locationPersistencePort;
+
+    @Mock
+    private CategoryPersistencePort categoryPersistencePort;
+
+    @InjectMocks
+    private PropertyUseCase propertyUseCase;
+    private PropertyModel propertyModel;
+    private final Long validLocation = 10L;
+    private final Long validCategory = 20L;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        propertyModel = new PropertyModel(
+                1L,
+                "Casa Familiar",
+                "Bonita casa con jardín",
+                validCategory,
+                3,
+                2,
+                new BigDecimal("2500000"),
+                validLocation,
+                LocalDate.of(2025, 4, 7),
+                PublicationStatus.PUBLISHED,
+                LocalDate.of(2025, 4, 8)
+        );
+    }
+    @Test
+    void saveProperty_validInput_callsPersistence() {
+
+
+        when(locationPersistencePort.findByLocationId(validLocation)).thenReturn(mock(LocationModel.class));
+        when(categoryPersistencePort.getCategoryById(validCategory)).thenReturn(mock(CategoryModel.class));
+        doNothing().when(propertyPersistencePort).save(any());
+
+        propertyUseCase.save(propertyModel);
+
+        verify(locationPersistencePort, times(1)).findByLocationId(validLocation);
+        verify(categoryPersistencePort, times(1)).getCategoryById(validCategory);
+        verify(propertyPersistencePort, times(1)).save(propertyModel);
+    }
+
+    @Test
+    void saveProperty_nonExistingLocation_throwsLocationNotFoundException() {
+        when(locationPersistencePort.findByLocationId(validLocation)).thenReturn(null);
+
+        assertThrows(LocationNotFoundException.class, () -> propertyUseCase.save(propertyModel));
+
+        verify(locationPersistencePort, times(1)).findByLocationId(validLocation);
+        verify(categoryPersistencePort, never()).getCategoryById(any());
+        verify(propertyPersistencePort, never()).save(any());
+    }
+
+    @Test
+    void saveProperty_nonExistingCategory_throwsCategoryNotFoundException() {
+        when(locationPersistencePort.findByLocationId(validLocation)).thenReturn(mock(LocationModel.class));
+        when(categoryPersistencePort.getCategoryById(validCategory)).thenReturn(null);
+
+        assertThrows(CategoryNotFoundException.class, () -> propertyUseCase.save(propertyModel));
+
+        verify(locationPersistencePort, times(1)).findByLocationId(validLocation);
+        verify(categoryPersistencePort, times(1)).getCategoryById(validCategory);
+        verify(propertyPersistencePort, never()).save(any());
+    }
+
+}
+

--- a/src/test/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCaseTest.java
+++ b/src/test/java/com/powerup/realestate/properties/domain/usecases/PropertyUseCaseTest.java
@@ -2,6 +2,7 @@ package com.powerup.realestate.properties.domain.usecases;
 
 import com.powerup.realestate.location.domain.model.LocationModel;
 import com.powerup.realestate.location.domain.ports.out.LocationPersistencePort;
+import com.powerup.realestate.properties.application.services.PropertyValidationService;
 import com.powerup.realestate.properties.domain.exceptions.CategoryNotFoundException;
 import com.powerup.realestate.properties.domain.exceptions.LocationNotFoundException;
 import com.powerup.realestate.properties.domain.model.CategoryModel;
@@ -17,6 +18,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,66 +35,72 @@ class PropertyUseCaseTest {
     @Mock
     private CategoryPersistencePort categoryPersistencePort;
 
+    @Mock
+    private PropertyValidationService propertyValidationService;
+
     @InjectMocks
     private PropertyUseCase propertyUseCase;
     private PropertyModel propertyModel;
-    private final Long validLocation = 10L;
-    private final Long validCategory = 20L;
+    private LocationModel validLocationModel;
+    private CategoryModel validCategoryModel;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        validCategoryModel = CategoryModel.builder().id(20L).name("Casa").description("Casa familiar").build();
+        validLocationModel = LocationModel.builder().id(10L).neighborhood("Centro").build();
+
         propertyModel = new PropertyModel(
                 1L,
                 "Casa Familiar",
                 "Bonita casa con jardín",
-                validCategory,
+                validCategoryModel,
                 3,
                 2,
                 new BigDecimal("2500000"),
-                validLocation,
+                validLocationModel,
                 LocalDate.of(2025, 4, 7),
                 PublicationStatus.PUBLISHED,
                 LocalDate.of(2025, 4, 8)
         );
-    }
-    @Test
-    void saveProperty_validInput_callsPersistence() {
 
-
-        when(locationPersistencePort.findByLocationId(validLocation)).thenReturn(mock(LocationModel.class));
-        when(categoryPersistencePort.getCategoryById(validCategory)).thenReturn(mock(CategoryModel.class));
+        // Configura el comportamiento del mock locationPersistencePort.
+        when(locationPersistencePort.findByLocationId(validLocationModel.getId())).thenReturn(Optional.ofNullable(validLocationModel));
+        when(categoryPersistencePort.getCategoryById(validCategoryModel.getId())).thenReturn(Optional.ofNullable(validCategoryModel));
         doNothing().when(propertyPersistencePort).save(any());
+        doNothing().when(propertyValidationService).validate(any());
+    }
 
+    @Test
+    void saveProperty_validInput_callsPersistenceAndValidation() {
         propertyUseCase.save(propertyModel);
 
-        verify(locationPersistencePort, times(1)).findByLocationId(validLocation);
-        verify(categoryPersistencePort, times(1)).getCategoryById(validCategory);
+        verify(propertyValidationService, times(1)).validate(propertyModel);
         verify(propertyPersistencePort, times(1)).save(propertyModel);
     }
 
     @Test
     void saveProperty_nonExistingLocation_throwsLocationNotFoundException() {
-        when(locationPersistencePort.findByLocationId(validLocation)).thenReturn(null);
+        when(locationPersistencePort.findByLocationId(validLocationModel.getId())).thenReturn(null);
+        doThrow(new LocationNotFoundException())
+                .when(propertyValidationService).validate(propertyModel);
 
         assertThrows(LocationNotFoundException.class, () -> propertyUseCase.save(propertyModel));
 
-        verify(locationPersistencePort, times(1)).findByLocationId(validLocation);
-        verify(categoryPersistencePort, never()).getCategoryById(any());
         verify(propertyPersistencePort, never()).save(any());
+        verify(propertyValidationService, times(1)).validate(propertyModel);
     }
 
     @Test
     void saveProperty_nonExistingCategory_throwsCategoryNotFoundException() {
-        when(locationPersistencePort.findByLocationId(validLocation)).thenReturn(mock(LocationModel.class));
-        when(categoryPersistencePort.getCategoryById(validCategory)).thenReturn(null);
+        when(categoryPersistencePort.getCategoryById(validCategoryModel.getId())).thenReturn(null);
+        doThrow(new CategoryNotFoundException())
+                .when(propertyValidationService).validate(propertyModel);
 
         assertThrows(CategoryNotFoundException.class, () -> propertyUseCase.save(propertyModel));
 
-        verify(locationPersistencePort, times(1)).findByLocationId(validLocation);
-        verify(categoryPersistencePort, times(1)).getCategoryById(validCategory);
         verify(propertyPersistencePort, never()).save(any());
+        verify(propertyValidationService, times(1)).validate(propertyModel);
     }
-
 }
 

--- a/src/test/java/com/powerup/realestate/properties/domain/utils/PublicationSchedulerTest.java
+++ b/src/test/java/com/powerup/realestate/properties/domain/utils/PublicationSchedulerTest.java
@@ -1,0 +1,38 @@
+package com.powerup.realestate.properties.domain.utils;
+import com.powerup.realestate.properties.domain.ports.out.PropertyPersistencePort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import java.time.LocalDate;
+import java.util.Collections;
+import static org.mockito.Mockito.*;
+
+class PublicationSchedulerTest {
+
+    @Mock
+    private PropertyPersistencePort propertyPersistencePort;
+
+    @InjectMocks
+    private PublicationScheduler publicationScheduler;
+    private LocalDate today;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        today = LocalDate.now();
+    }
+
+    @Test
+    void activatePendingPublications_noPausedProperties() {
+        when(propertyPersistencePort.findByPublicationStatus(PublicationStatus.PUBLISHING_PAUSED))
+                .thenReturn(Collections.emptyList());
+
+        publicationScheduler.activatePendingPublications();
+
+        verify(propertyPersistencePort, times(1)).findByPublicationStatus(PublicationStatus.PUBLISHING_PAUSED);
+        verify(propertyPersistencePort, never()).update(any());
+    }
+
+}

--- a/src/test/java/com/powerup/realestate/properties/domain/utils/PublicationSchedulerTest.java
+++ b/src/test/java/com/powerup/realestate/properties/domain/utils/PublicationSchedulerTest.java
@@ -31,7 +31,8 @@ class PublicationSchedulerTest {
 
         publicationScheduler.activatePendingPublications();
 
-        verify(propertyPersistencePort, times(1)).findByPublicationStatus(PublicationStatus.PUBLISHING_PAUSED);
+        verify(propertyPersistencePort, times(1))
+                .findByPublicationStatus(PublicationStatus.PUBLISHING_PAUSED);
         verify(propertyPersistencePort, never()).update(any());
     }
 


### PR DESCRIPTION
- Cada propiedad debe estar asociada a una única categoría de inmueble.

- La propiedad solo será visible para los usuarios si la fechaPublicacionActiva es igual o anterior a la fecha actual.

- La fechaPublicacionActiva no puede exceder un mes a partir de la fecha actual (se valida en el servicio de validación).

- Se agregó enumeración PublicationStatus con los estados de publicación posibles.

- Se actualizó el servicio de publicación para verificar la visibilidad de la propiedad con base en la fecha actual.

- Se implementó PublicationScheduler para cambiar automáticamente el estado de la publicación si la fecha activa lo permite.

